### PR TITLE
CRAYSAT-1417: SAT documentation RPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode
 .idea
+dist/

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,0 +1,97 @@
+/*
+ * MIT License
+ *
+ * (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+@Library('csm-shared-library') _
+
+pipeline {
+    agent {
+        label 'metal-gcp-builder'
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+        timestamps()
+    }
+
+    environment {
+        NAME = 'docs-sat'
+        IS_STABLE = getBuildIsStable(releaseBranchIsStable: true)
+        VERSION = sh(script: './version.sh', returnStdout: true).trim()
+        COMMIT_COUNT = sh(script: './commit_count.sh', returnStdout: true).trim()
+        BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE, buildRef: env.COMMIT_COUNT)
+    }
+
+    stages {
+
+        stage('Build RPM Package') {
+            agent {
+                docker {
+                    image 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.3'
+                    reuseNode true
+                }
+            }
+            steps {
+                sh 'make prepare'
+                sh 'make rpm_package_source'
+                sh 'make rpm_build_source'
+                sh 'make rpm_build'
+            }
+        }
+
+        stage('Publish') {
+            steps {
+                script{
+                    def artifactory_component = env.NAME
+                    if (env.IS_STABLE.toBoolean()) {
+                        /*
+                         * Create a -latest RPM file, e.g. if building
+                         * docs-sat-2.4.1-1.noarch.rpm, also create docs-sat-latest.noarch.rpm.
+                         * Only do this for stable builds in which we will publish to a MAJOR.MINOR-specific
+                         * subdirectory.
+                         */
+                        sh 'cp dist/rpmbuild/RPMS/noarch/docs-sat-*.noarch.rpm dist/rpmbuild/RPMS/noarch/docs-sat-latest.noarch.rpm'
+                        artifactory_component = "${env.NAME}/${env.VERSION}"
+                    }
+                    publishCsmRpms(
+                        artifactoryRepo: 'sat-rpms',
+                        os: 'sle-15sp3',
+                        component: artifactory_component,
+                        pattern: 'dist/rpmbuild/RPMS/noarch/*.rpm',
+                        arch: 'noarch',
+                        isStable: env.IS_STABLE
+                    )
+                    publishCsmRpms(
+                        artifactoryRepo: 'sat-rpms',
+                        os: 'sle-15sp3',
+                        component: artifactory_component,
+                        pattern: 'dist/rpmbuild/SRPMS/*.rpm',
+                        arch: 'src',
+                        isStable: env.IS_STABLE
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+NAME ?= docs-sat
+VERSION ?= $(shell ./version.sh)
+BUILD_METADATA ?= 1~development~$(shell git rev-parse --short HEAD)
+
+SPEC_FILE ?= ${NAME}.spec
+SOURCE_NAME ?= ${NAME}
+BUILD_DIR ?= $(PWD)/dist/rpmbuild
+SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}-${VERSION}.tar.bz2
+
+rpm: prepare rpm_package_source rpm_build_source rpm_build
+
+prepare:
+	rm -rf $(BUILD_DIR)
+	mkdir -p $(BUILD_DIR)/SPECS $(BUILD_DIR)/SOURCES
+	cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/
+
+rpm_package_source:
+	tar --transform 'flags=r;s,^,/$(NAME)-$(VERSION)/,' --exclude .git --exclude dist -cvjf $(SOURCE_PATH) .
+
+rpm_build_source:
+	BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ts $(SOURCE_PATH) --define "_topdir $(BUILD_DIR)"
+
+rpm_build:
+	BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ba $(SPEC_FILE) --define "_topdir $(BUILD_DIR)"

--- a/commit_count.sh
+++ b/commit_count.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Get the number of commits since the last version tag
+long_version=$(git describe --tags --long --match 'v*')
+commit_count=$(echo $long_version | cut -d "-" -f 2)
+echo "$commit_count"

--- a/docs-sat.spec
+++ b/docs-sat.spec
@@ -1,0 +1,60 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# RPM specfile for docs-sat RPM
+
+Name: docs-sat
+License: MIT License
+Summary: Documentation for System Admin Toolkit (SAT)
+BuildArchitectures: noarch
+Version: %(./version.sh)
+Release: %(echo ${BUILD_METADATA})
+Source: %{name}-%{version}.tar.bz2
+Vendor: Hewlett Packard Enterprise Company
+
+%description
+This package contains documentation about the System Admin Toolkit (SAT)
+in Markdown format starting at /usr/share/doc/sat/README.md.
+
+%prep
+%setup -q
+
+%build
+
+%install
+install -m 755 -d %{buildroot}/usr/share/doc/sat/
+# The docs/ directory will be installed in /usr/share/doc/sat/
+cp -pvr docs/* %{buildroot}/usr/share/doc/sat/
+# Except that README.md will be rpm/README.md concatenated with docs/README.md
+cat rpm/README.md > %{buildroot}/usr/share/doc/sat/README.md
+# Add an empty line between the files.
+echo >> %{buildroot}/usr/share/doc/sat/README.md
+cat docs/README.md >> %{buildroot}/usr/share/doc/sat/README.md
+
+%clean
+
+%files
+/usr/share/doc/sat/
+
+%docdir /usr/share/doc/sat/
+%license LICENSE

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -1,0 +1,45 @@
+# System Admin Toolkit Offline Documentation
+
+The SAT documentation can be found online at the following url:
+https://cray-hpe.github.io/docs-sat
+
+It is also available offline as markdown, which may be viewed with a markdown
+viewer or with a text editor. A table of contents can be found below.
+
+The offline documentation is available in the `docs/` directory of the SAT
+release distribution as well as in RPM package format. The RPM package is
+installed as a part of the Ansible plays launched by the Configuration
+Framework Service (CFS). Its files are installed to `/usr/share/doc/sat`.
+
+## Check for Latest Documentation
+
+Acquire the latest documentation RPM. This may include updates, corrections,
+and enhancements that were not available until after the software release.
+
+1. Check the version of the currently installed SAT documentation.
+
+   This RPM will only be installed if the SAT CFS configuration layer has been
+   applied.
+
+   ```
+   rpm -q docs-sat
+   ```
+
+2. Download and upgrade the latest documentation RPM.
+
+   For example, to download and upgrade to the latest SAT 2.4 documentation RPM:
+
+   ```
+   rpm -Uvh https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/docs-sat/2.4/noarch/docs-sat-latest.noarch.rpm
+   ```
+
+   If this machine does not have direct internet access, then this RPM will
+   need to be externally downloaded and copied to the system. The following
+   example copies it to `ncn-m001`.
+
+   ```
+   wget https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/docs-sat/2.4/noarch/docs-sat-latest.noarch.rpm -O docs-sat-latest.noarch.rpm
+   scp -p docs-sat-latest.noarch.rpm ncn-m001:/root
+   ssh ncn-m001
+   rpm -Uvh docs-sat-latest.noarch.rpm
+   ```

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Get the docs-sat version
+long_version=$(git describe --tags --long --match 'v*')
+major_minor_version=${long_version%%-*}
+major_minor_version=${major_minor_version/v/}
+echo "$major_minor_version"


### PR DESCRIPTION
This commit adds an RPM build of the SAT documentation.

Add a Makefile, RPM spec file, and .version file all used for the
building of the docs-sat RPM. The RPM will install all the markdown
files in the docs/ directory of this repository into
/usr/share/doc/sat/, except that docs/README.md is renamed
docs/index.md, and rpm/README.md is added in its place (i.e.,
installed at /usr/share/doc/sat/README.md).

This commit adds Jenkinsfile.github for building the RPM in a Jenkins
pipeline. The RPM is published to one of two locations depending on
whether the build is stable. For stable builds, the RPM is published
to: "sat-rpms/hpe/stable/sle-15sp3/docs-sat/X.Y/noarch/" where X and Y
are the major/minor version numbers of SAT (e.g. 2.4). Additionally,
when publishing a stable RPM, a version named
"docs-sat-latest.noarch.rpm" is published alongside the usual
"docs-sat-X.Y.Z.noarch.rpm", in the same directory.

For unstable builds (e.g., development branches), they are published
to "sat-rpms/hpe/unstable/sle-15sp3/docs-sat/noarch" (note the
"unstable" directory and lack of major.minor subdirectory).

For both stable and unstable builds, source RPMs are published
to the same locations in artifactory, except under a "src"
directory rather than "noarch" (e.g., a stable build would be
published to: "sat-rpms/hpe/stable/sle-15sp3/docs-sat/X.Y/src/")

Test Description:
* I built the RPM and installed it.
* Ran `rpm -ql` on the installed RPM to list the files.
* Ran `rpm -qi` on the installed RPM to view the RPM info.
* Uninstalled the RPM, verified that the directory was removed.
* I created a test "stable" branch to verify that stable builds
  were being published to the expected stable location.
* I created a test "stable" build of the product stream to verify
  that the RPM can be pulled from the stable location.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable