### PR TITLE
CRAYSAT-1494: Add SAT 2.3 release notes to 2.4 release branch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@
 
 ## [SAT Release Notes](release_notes.md)
 
-- [Summary of changes in SAT 2.2](release_notes.md#summary-of-changes-in-sat-22)
+- [Summary of changes in SAT 2.3](release_notes.md#summary-of-changes-in-sat-23)
 - [Summary of SAT changes in Shasta v1.5](release_notes.md#summary-of-sat-changes-in-shasta-v15)
 - [Summary of SAT Changes in Shasta v1.4.1](release_notes.md#summary-of-sat-changes-in-shasta-v141)
 - [Summary of SAT Changes in Shasta v1.4](release_notes.md#summary-of-sat-changes-in-shasta-v14)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,92 @@
 # SAT Release Notes
 
+## Summary of Changes in SAT 2.3
+
+The 2.3.4 version of the SAT product includes:
+
+- Version 3.15.4 of the sat python package and CLI
+- Version 1.6.11 of the sat-podman wrapper script
+- Version 1.2.0 of the sat-cfs-install container image
+- Version 2.0.0 of the sat-cfs-install Helm chart
+- Version 1.5.0 of the sat-install-utility container image
+- Version 2.0.3 of the cfs-config-util container image
+
+### New `sat` Commands
+
+None.
+
+### Current Working Directory in SAT Container
+
+When running `sat` commands, the current working directory is now mounted in the
+container as `/sat/share`, and the current working directory within the container
+is also `/sat/share`.
+
+Files in the current working directory must be specified using relative paths to
+that directory, because the current working directory is always mounted on `/sat/share`.
+Absolute paths should be avoided, and paths that are outside of `$HOME` or `$PWD`
+are never accessible to the container environment.
+
+The home directory is still mounted on the same path inside the container as it
+is on the host.
+
+### Changes to `sat bootsys`
+
+The following options were added to `sat bootsys`.
+
+- `--bos-limit`
+- `--recursive`
+
+The `--bos-limit` option passes a given limit string to a BOS session. The `--recursive`
+option specifies a slot or other higher-level component in the limit string
+
+### Changes to `sat bootprep`
+
+The `--delete-ims-jobs` option was added to `sat bootprep run`. It deletes IMS
+jobs after `sat bootprep` is run. Jobs are no longer deleted by default.
+
+### Changes to `sat status`
+
+`sat status` now includes information about nodes' CFS configuration statuses, such
+as desired configuration, configuration status, and error count.
+
+The output of `sat status` now splits different component types into different report tables.
+
+The following options were added to `sat status`.
+
+- `--hsm-fields`, `--sls-fields`, `--cfs-fields`
+- `--bos-template`
+
+The `--hsm-fields`, `--sls-fields`, `--cfs-fields` options limit the output columns
+according to specified CSM services.
+
+The `--bos-template` option filters the status report according to the specified
+session template's boot sets.
+
+### Compatibility with CSM 1.2
+
+The following components were modified to be compatible with CSM 1.2.
+
+- `sat-cfs-install` container image and Helm chart
+- `sat-install-utility` container image
+- SAT product installer
+
+### GPG Checking
+
+The `sat-ncn` ansible role provided by `sat-cfs-install` was modified to enable
+GPG checks on packages while leaving GPG checks disabled on repository metadata.
+
+### Security
+
+Updated urllib3 dependency to version 1.26.5 to mitigate CVE-2021-33503 and refreshed
+Python dependency versions.
+
+### Bug Fixes
+
+Minor bug fixes were made in each of the repositories. For full change lists, see each
+repository’s CHANGELOG.md file.
+
+The known issue in which the `sat` command was not available by default in `sat bash` was fixed.
+
 ## Summary of changes in SAT 2.2
 
 SAT 2.2.16 was released on February 25th, 2022.


### PR DESCRIPTION
## Summary and Scope

This change cherry-picks the 2.3 release notes from integration onto the 2.4 release branch.

## Issues and Related PRs

* Resolves [CRAYSAT-1494](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1494)

## Testing

### Tested on:

  * Local development environment

### Test description:


Docs were built using the CSM docs web builder and inspected for errors.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
