### PR TITLE
CRAYSAT-1549: Document SAT inclusion in CSM

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,7 +26,9 @@ are reported through Redfish.
 - [Grafana Fabric Port State Dashboard](dashboards/SAT_Grafana_Dashboards.md#grafana-fabric-port-state-dashboard)
 - [Grafana Fabric RFC3635 Dashboard](dashboards/SAT_Grafana_Dashboards.md#grafana-fabric-rfc3635-dashboard)
 
-SAT is installed as a separate product as part of the HPE Cray EX System base installation.
+In CSM 1.3 and newer, the `sat` command is automatically available on all the Kubernetes NCNs. See
+[SAT in CSM](#sat-in-csm) for more information. Older versions of CSM do not have the `sat` command automatically
+available, and SAT must be installed as a separate product.
 
 ## System Admin Toolkit Command Overview
 
@@ -137,6 +139,41 @@ ncn-m001# sat status
 ncn-m001# sat bash
 (CONTAINER_ID) sat-container# sat status
 ```
+
+## SAT in CSM
+
+In CSM 1.3 and newer, the `sat` command is automatically available on all the Kubernetes NCNs, but it is still possible
+to install SAT as a separate product stream. Any version of SAT installed as a separate product stream overrides the
+`sat` command available in CSM. Installing the SAT product stream allows additional supporting components to be added:
+
+- An entry for SAT in the `cray-product-catalog` Kubernetes ConfigMap is only created by installing the SAT product
+  stream. Otherwise, there will be no entry for this version of SAT in the output of `sat showrev`.
+
+- The `sat-install-utility` container image is only available with the full SAT product stream. This container image
+  provides uninstall and activate functionality when used with the `prodmgr` command. (In SAT 2.3 and older, SAT was
+  only available to install as a separate product stream. Because these versions were packaged with
+  `sat-install-utility`, it is still possible to uninstall these versions of SAT.)
+
+- The `docs-sat` RPM package is only available with the full SAT product stream.
+
+- The `sat-config-management` git repository in Gitea (VCS) and thus the SAT layer of NCN CFS configuration is
+  only available with the full SAT product stream.
+
+If the SAT product stream is not installed, there will be no configuration content for SAT in VCS. Therefore, CFS
+configurations that apply to NCNs (for example, `ncn-personalization`) should not include a SAT layer.
+
+The SAT configuration layer modifies the permissions of files left over from prior installations of SAT, so that the
+Keycloak username that authenticates to the API gateway cannot be read by users other than `root`. Specifically, it
+it does the following:
+
+- Modifies the `sat.toml` configuration file which contains the username so that it is only readable by `root`.
+
+- Modifies the `/root/.config/sat/tokens` directory so that the directory is only readable by `root`. This is needed
+  because the names of the files within the `tokens` directory contain the username.
+
+Regardless of the SAT configuration being applied, passwords and the contents of the tokens are never readable by other
+users. These permission changes only apply to files created by previous installations of SAT. In the current version of
+SAT all files and directories are created with the appropriate permissions.
 
 ## SAT Dependencies
 


### PR DESCRIPTION
* Add notes about SAT being automatically included in CSM 1.3.
* Document components that are not included in this "bundled" version.
* Specifically mention CFS configuration content.

## Issues and Related PRs

* Resolves [CRAYSAT-1549](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1549)
* An additional PR will be needed to the release/2.4 branch.
* See also: https://github.com/Cray-HPE/docs-csm/pull/2366

## Testing

Spell check and style check

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable