### PR TITLE
CRAYSAT-1562: Include "type=Node" in HSM query for CFS configurations

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -179,7 +179,7 @@ SAT.
 1.  Run the script with the following options:
 
     ```screen
-    ncn-m001# ./update-mgmt-ncn-cfs-config.sh --base-query role=Management --save
+    ncn-m001# ./update-mgmt-ncn-cfs-config.sh --base-query role=Management,type=Node --save
     ```
 
 1.  Examine the output to ensure the CFS configuration was updated.


### PR DESCRIPTION
## Summary and Scope
To workaround CRAYSAT-1561, document running the
`update-mgmt-ncn-cfs-config.sh` script with the additional argument `type=Node`. This will eliminate the warning messages that come from querying CFS for configurations that apply to NodeBMCs.

(cherry picked from commit 822a69e963a0e9202c291f8d79fb1f468928ca0a)

## Issues and Related PRs

* Resolves [CRAYSAT-1562](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1562)

## Testing

### Tested on:

  * surtur

### Test Description:

Tested this command during an install of SAT 2.4.11 on surtur.

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

