### PR TITLE
CRAYSAT-1572: Add missing link in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [About System Admin Toolkit (SAT)](introduction.md#about-system-admin-toolkit-sat)
 - [System Admin Toolkit Command Overview](introduction.md#system-admin-toolkit-command-overview)
 - [Command Prompt Conventions in SAT](introduction.md#command-prompt-conventions-in-sat)
+- [SAT in CSM](introduction.md#sat-in-csm)
 - [SAT Dependencies](introduction.md#sat-dependencies)
 
 ## [SAT Installation](install.md)


### PR DESCRIPTION
This commit adds a missing link from the top-level README.md file to the subsection of introduction.md detailing SAT inclusion in CSM.

Test Description: After pushing this branch, I verified the link worked viewing the docs in GitHub.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

