### PR TITLE
STP-3310: Add SAT cne-install information

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -43,6 +43,7 @@ Slurm
 EX-1C
 CSM-Diags
 Loftsman
+S-8000
 S-8001
 XName
 XNames
@@ -63,6 +64,7 @@ passwordless
 pre-installation
 pre-ncn-personalization
 pre-populated
+pre-upgrade
 prepended
 runtime
 subcommand

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,13 @@
 - [Uninstall: Removing a Version of SAT](install.md#uninstall-removing-a-version-of-sat)
 - [Activate: Switching Between Versions](install.md#activate-switching-between-versions)
 
+## [SAT Upgrade with CNE Installer](cne-install.md)
+
+- [Upgrade the System Admin Toolkit Product Stream](cne-install.md#upgrade-the-system-admin-toolkit-product-stream)
+- [Post-Upgrade Cleanup Procedure](cne-install.md#post-upgrade-cleanup-procedure)
+- [Remove Obsolete Configuration File Sections](cne-install.md#remove-obsolete-configuration-file-sections)
+- [SAT Logging](cne-install.md#sat-logging)
+
 ## [SAT Dashboards](dashboards/README.md)
 
 - [SAT Kibana Dashboards](dashboards/SAT_Kibana_Dashboards.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,12 +31,12 @@
 - [Uninstall: Removing a Version of SAT](install.md#uninstall-removing-a-version-of-sat)
 - [Activate: Switching Between Versions](install.md#activate-switching-between-versions)
 
-## [SAT Upgrade with CNE Installer](cne-install.md)
+## [SAT Upgrade with CNE Installer](cne_install.md)
 
-- [Upgrade the System Admin Toolkit Product Stream](cne-install.md#upgrade-the-system-admin-toolkit-product-stream)
-- [Post-Upgrade Cleanup Procedure](cne-install.md#post-upgrade-cleanup-procedure)
-- [Remove Obsolete Configuration File Sections](cne-install.md#remove-obsolete-configuration-file-sections)
-- [SAT Logging](cne-install.md#sat-logging)
+- [Upgrade the System Admin Toolkit Product Stream](cne_install.md#upgrade-the-system-admin-toolkit-product-stream)
+- [Post-Upgrade Cleanup Procedure](cne_install.md#post-upgrade-cleanup-procedure)
+- [Remove Obsolete Configuration File Sections](cne_install.md#remove-obsolete-configuration-file-sections)
+- [SAT Logging](cne_install.md#sat-logging)
 
 ## [SAT Dashboards](dashboards/README.md)
 

--- a/docs/cne-install.md
+++ b/docs/cne-install.md
@@ -5,66 +5,78 @@
 Describes how to upgrade the System Admin Toolkit (SAT) product
 stream by using the Compute Node Environment (CNE) installer (`cne-install`).
 
-The CNE installer can only upgrade the SAT product stream for this release. See [Install the System Admin Toolkit Product Stream](install.md) for installation instructions.
+The CNE installer can only upgrade the SAT product stream for this release. See
+[Install the System Admin Toolkit Product Stream](install.md) for installation
+instructions.
 
-Upgrading SAT with `cne-install` is recommended because the process is both automated and logged to help you save time. The CNE installer can be used to upgrade SAT alone or with other supported products. Refer to the [*HPE Cray EX System Software Getting Started Guide (S-8000)*](https://www.hpe.com/support/ex-S-8000) for detailed information about `cne-install` and its options.
+Upgrading SAT with `cne-install` is recommended because the process is both
+automated and logged to help you save time. The CNE installer can be used to
+upgrade SAT alone or with other supported products. Refer to the [*HPE Cray EX
+System Software Getting Started Guide (S-8000)*](https://www.hpe.com/support/ex-S-8000)
+for detailed information about `cne-install` and its options.
 
 ### Prerequisites
 
 - CSM is installed and verified.
-- cray-product-catalog is running.
-- There must be at least 2 gigabytes of free space on the manager NCN on which the
-  procedure is run.
+- There must be at least 2 gigabytes of free space on the manager NCN on which
+the procedure is run.
 
 ### Notes on the Procedures
 
 - Ellipses (`...`) in shell output indicate omitted lines.
 - In the examples below, replace `x.y.z` with the version of the SAT product stream
-  being upgraded.
+being upgraded.
 - 'manager' and 'master' are used interchangeably in the steps below.
 
 ### Pre-Upgrade Procedure
 
-1.  Start a typescript and set the shell prompt.
+1. Start a typescript and set the shell prompt.
 
-    The typescript will record the commands and the output from this upgrade.
-    The prompt is set to include the date and time.
+   The typescript will record the commands and the output from this upgrade.
+   The prompt is set to include the date and time.
 
-    ```screen
-    ncn-m001# script -af product-sat.$(date +%Y-%m-%d).txt
-    ncn-m001# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
-    ```
+   ```screen
+   ncn-m001# script -af product-sat.$(date +%Y-%m-%d).txt
+   ncn-m001# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+   ```
 
 ### Upgrade Procedure
 
-1.  Copy the release distribution gzipped tar file to `ncn-m001`.
+1. Copy the release distribution gzipped tar file to `ncn-m001`.
 
-    Whether you are upgrading SAT alone or with other supported products, copy the file in the same media directory as all other supported products.
+   Whether you are upgrading SAT alone or with other supported products, copy
+   the file in the same media directory as all other supported products.
 
-1.  Run the CNE installer.
+   **NOTE:** The `cne-install` command installs all files in the media directory
+   by default. If you are upgrading SAT alone, ensure only the SAT tarball is in
+   the media directory.
 
-    - If you are upgrading SAT along with other supported products, run the following command.
+1. Run the CNE installer.
 
-        ```screen
-        ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH -bpc BOOTPREP_CONFIG_CN -bpn BOOTPREP_CONFIG_NCN
-        ```
+     - If you are upgrading SAT along with other supported products, run the
+following command.
 
-        The `cne-install` command will use the provided `BOOTPREP_CONFIG_CN` and `BOOTPREP_CONFIG_NCN` files for the run.
+     ```screen
+     ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH -bpc BOOTPREP_CONFIG_CN -bpn
+BOOTPREP_CONFIG_NCN
+     ```
 
-    - If you are upgrading SAT alone, run the following command.
+     The `cne-install` command will use the provided `BOOTPREP_CONFIG_CN` and
+     `BOOTPREP_CONFIG_NCN` files for the run.
 
-        ```screen
-        ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH
-        ```
+     - If you are upgrading SAT alone, refer to "Appendix A" of the [*HPE Cray EX System
+Software Getting Started Guide (S-8000)*](https://www.hpe.com/support/ex-S-8000).
+Review the detailed information available here to determine which stages to
+run and options to choose for `cne-install`.
 
-1.  **Optional:** Stop the typescript.
+1. **Optional:** Stop the typescript.
 
-    **NOTE**: This step can be skipped if you wish to use the same typescript
-    for the remainder of the SAT upgrade. See [Next Steps](#next-steps).
+   **NOTE**: This step can be skipped if you wish to use the same typescript
+   for the remainder of the SAT upgrade. See [Next Steps](#next-steps).
 
-    ```screen
-    ncn-m001# exit
-    ```
+   ```screen
+   ncn-m001# exit
+   ```
 
 SAT version `x.y.z` is now upgraded, meaning the SAT `x.y.z` release
 has been loaded into the system software repository.
@@ -80,8 +92,9 @@ At this point, the release distribution files can be removed from the system as
 described in [Post-Upgrade Cleanup Procedure](#post-upgrade-cleanup-procedure).
 
 If other HPE Cray EX software products are being upgraded in conjunction
-with SAT, refer to the [*HPE Cray EX System Software Getting Started Guide (S-8000)*](https://www.hpe.com/support/ex-S-8000)
-to determine which step to execute next.
+with SAT, refer to the [*HPE Cray EX System Software Getting Started Guide
+(S-8000)*](https://www.hpe.com/support/ex-S-8000) to determine which step
+to execute next.
 
 If no other HPE Cray EX software products are being upgraded at this time,
 execute the **SAT Post-Upgrade** procedures:
@@ -91,32 +104,34 @@ execute the **SAT Post-Upgrade** procedures:
 
 ## Post-Upgrade Cleanup Procedure
 
-1.  **Optional:** Remove the SAT release distribution tar file and extracted directory.
+1. **Optional:** Remove the SAT release distribution tar file and extracted directory.
 
-    ```screen
-    ncn-m001# rm sat-x.y.z.tar.gz
-    ncn-m001# rm -rf sat-x.y.z/
-    ```
+   ```screen
+   ncn-m001# rm sat-x.y.z.tar.gz
+   ncn-m001# rm -rf sat-x.y.z/
+   ```
 
 ## Remove Obsolete Configuration File Sections
 
 ### Prerequisites
 
 - The [Upgrade the System Admin Toolkit Product Stream](#upgrade-the-system-admin-toolkit-product-stream)
-  procedure has been successfully completed.
+procedure has been successfully completed.
 
 ### Procedure
 
-After upgrading SAT, if using the configuration file from a previous version, there may be
-configuration file sections no longer used in the new version. For example, when upgrading
-from Shasta 1.4 to Shasta 1.5, the `[redfish]` configuration file section is no longer used.
-In that case, the following warning may appear upon running `sat` commands.
+After upgrading SAT, if using the configuration file from a previous version,
+there may be configuration file sections no longer used in the new version.
+For example, when upgrading from Shasta 1.4 to Shasta 1.5, the `[redfish]`
+configuration file section is no longer used. In that case, the following
+warning may appear upon running `sat` commands.
 
 ```screen
 WARNING: Ignoring unknown section 'redfish' in config file.
 ```
 
-Remove the `[redfish]` section from `/root/.config/sat/sat.toml` to resolve the warning.
+Remove the `[redfish]` section from `/root/.config/sat/sat.toml` to resolve
+the warning.
 
 ```screen
 [redfish]
@@ -124,7 +139,8 @@ username = "admin"
 password = "adminpass"
 ```
 
-Repeat this process for any configuration file sections for which there are "unknown section" warnings.
+Repeat this process for any configuration file sections for which there are
+"unknown section" warnings.
 
 ## SAT Logging
 
@@ -140,7 +156,7 @@ that important output is shown in the terminal.
 
 ### Update Configuration
 
-In the following example, the stderr log level, `logging.stderr_level`, is set to
+In the following example, the `stderr` log level, `logging.stderr_level`, is set to
 `WARNING`, which will exclude `INFO`-level logging from terminal output.
 
 ```screen
@@ -162,7 +178,7 @@ the new default behavior.
 The following commands trigger messages that have been changed from `stdout`
 print calls to `INFO`-level (or `WARNING`- or `ERROR`-level) log messages:
 
-```
+```screen
 sat bootsys --stage shutdown --stage session-checks
 sat sensors
 ```
@@ -170,7 +186,7 @@ sat sensors
 The following commands trigger messages that have been changed from `INFO`-level
 log messages to `DEBUG`-level log messages:
 
-```
+```screen
 sat nid2xname
 sat xname2nid
 sat swap

--- a/docs/cne-install.md
+++ b/docs/cne-install.md
@@ -4,15 +4,14 @@
 
 Describes how to upgrade the System Admin Toolkit (SAT) product
 stream by using the Compute Node Environment (CNE) installer (`cne-install`).
-
-The CNE installer can only upgrade the SAT product stream for this release. See
-[Install the System Admin Toolkit Product Stream](install.md) for installation
-instructions.
+The CNE installer can be used only for upgrades and not for fresh installations.
+See [Install the System Admin Toolkit Product Stream](install.md) for
+installation instructions.
 
 Upgrading SAT with `cne-install` is recommended because the process is both
 automated and logged to help you save time. The CNE installer can be used to
 upgrade SAT alone or with other supported products. Refer to the [*HPE Cray EX
-System Software Getting Started Guide (S-8000)*](https://www.hpe.com/support/ex-S-8000)
+System Software Getting Started Guide (S-8000)*](<https://www.hpe.com/support/ex-S-8000>)
 for detailed information about `cne-install` and its options.
 
 ### Prerequisites
@@ -44,10 +43,7 @@ being upgraded.
 
 1. Copy the release distribution gzipped tar file to `ncn-m001`.
 
-   Whether you are upgrading SAT alone or with other supported products, copy
-   the file in the same media directory as all other supported products.
-
-   **NOTE:** The `cne-install` command installs all files in the media directory
+   The `cne-install` command installs all files in the media directory
    by default. If you are upgrading SAT alone, ensure only the SAT tarball is in
    the media directory.
 
@@ -57,17 +53,21 @@ being upgraded.
 following command.
 
      ```screen
-     ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH -bpc BOOTPREP_CONFIG_CN -bpn
-BOOTPREP_CONFIG_NCN
+     ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH -bpc BOOTPREP_CONFIG_CN \
+         -bpn BOOTPREP_CONFIG_NCN
      ```
 
      The `cne-install` command will use the provided `BOOTPREP_CONFIG_CN` and
      `BOOTPREP_CONFIG_NCN` files for the run.
 
-     - If you are upgrading SAT alone, refer to "Appendix A" of the [*HPE Cray EX System
-Software Getting Started Guide (S-8000)*](https://www.hpe.com/support/ex-S-8000).
-Review the detailed information available here to determine which stages to
-run and options to choose for `cne-install`.
+     - If you are upgrading SAT alone, run the following commands.
+
+     ```screen
+     ncn-m001# cne-install -m MEDIA_DIR install -B '{{product_type}}-{{version_x_y_z}}' /
+         -bpn BOOTPREP_CONFIG_NCN -e update_working_branches
+     ncn-m001# cne-install -m MEDIA_DIR install -B '{{product_type}}-{{version_x_y_z}}' /
+         -bpn BOOTPREP_CONFIG_NCN -b sat_bootprep_ncn -e ncn_personalization
+     ```
 
 1. **Optional:** Stop the typescript.
 
@@ -93,7 +93,7 @@ described in [Post-Upgrade Cleanup Procedure](#post-upgrade-cleanup-procedure).
 
 If other HPE Cray EX software products are being upgraded in conjunction
 with SAT, refer to the [*HPE Cray EX System Software Getting Started Guide
-(S-8000)*](https://www.hpe.com/support/ex-S-8000) to determine which step
+(S-8000)*](<https://www.hpe.com/support/ex-S-8000>) to determine which step
 to execute next.
 
 If no other HPE Cray EX software products are being upgraded at this time,

--- a/docs/cne-install.md
+++ b/docs/cne-install.md
@@ -178,16 +178,12 @@ the new default behavior.
 The following commands trigger messages that have been changed from `stdout`
 print calls to `INFO`-level (or `WARNING`- or `ERROR`-level) log messages:
 
-```screen
-sat bootsys --stage shutdown --stage session-checks
-sat sensors
-```
+- `sat bootsys --stage shutdown --stage session-checks`
+- `sat sensors`
 
 The following commands trigger messages that have been changed from `INFO`-level
 log messages to `DEBUG`-level log messages:
 
-```screen
-sat nid2xname
-sat xname2nid
-sat swap
-```
+- `sat nid2xname`
+- `sat xname2nid`
+- `sat swap`

--- a/docs/cne-install.md
+++ b/docs/cne-install.md
@@ -1,0 +1,177 @@
+# SAT Upgrade with CNE Installer
+
+## Upgrade the System Admin Toolkit Product Stream
+
+Describes how to upgrade the System Admin Toolkit (SAT) product
+stream by using the Compute Node Environment (CNE) installer (`cne-install`).
+
+The CNE installer can only upgrade the SAT product stream for this release. See [Install the System Admin Toolkit Product Stream](install.md) for installation instructions.
+
+Upgrading SAT with `cne-install` is recommended because the process is both automated and logged to help you save time. The CNE installer can be used to upgrade SAT alone or with other supported products. Refer to the [*HPE Cray EX System Software Getting Started Guide (S-8000)*](https://www.hpe.com/support/ex-S-8000) for detailed information about `cne-install` and its options.
+
+### Prerequisites
+
+- CSM is installed and verified.
+- cray-product-catalog is running.
+- There must be at least 2 gigabytes of free space on the manager NCN on which the
+  procedure is run.
+
+### Notes on the Procedures
+
+- Ellipses (`...`) in shell output indicate omitted lines.
+- In the examples below, replace `x.y.z` with the version of the SAT product stream
+  being upgraded.
+- 'manager' and 'master' are used interchangeably in the steps below.
+
+### Pre-Upgrade Procedure
+
+1.  Start a typescript and set the shell prompt.
+
+    The typescript will record the commands and the output from this upgrade.
+    The prompt is set to include the date and time.
+
+    ```screen
+    ncn-m001# script -af product-sat.$(date +%Y-%m-%d).txt
+    ncn-m001# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
+
+### Upgrade Procedure
+
+1.  Copy the release distribution gzipped tar file to `ncn-m001`.
+
+    Whether you are upgrading SAT alone or with other supported products, copy the file in the same media directory as all other supported products.
+
+1.  Run the CNE installer.
+
+    - If you are upgrading SAT along with other supported products, run the following command.
+
+        ```screen
+        ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH -bpc BOOTPREP_CONFIG_CN -bpn BOOTPREP_CONFIG_NCN
+        ```
+
+        The `cne-install` command will use the provided `BOOTPREP_CONFIG_CN` and `BOOTPREP_CONFIG_NCN` files for the run.
+
+    - If you are upgrading SAT alone, run the following command.
+
+        ```screen
+        ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH
+        ```
+
+1.  **Optional:** Stop the typescript.
+
+    **NOTE**: This step can be skipped if you wish to use the same typescript
+    for the remainder of the SAT upgrade. See [Next Steps](#next-steps).
+
+    ```screen
+    ncn-m001# exit
+    ```
+
+SAT version `x.y.z` is now upgraded, meaning the SAT `x.y.z` release
+has been loaded into the system software repository.
+
+- SAT configuration content for this release has been uploaded to VCS.
+- SAT content for this release has been uploaded to the CSM product catalog.
+- SAT content for this release has been uploaded to Nexus repositories.
+- The `sat` command is available.
+
+### Next Steps
+
+At this point, the release distribution files can be removed from the system as
+described in [Post-Upgrade Cleanup Procedure](#post-upgrade-cleanup-procedure).
+
+If other HPE Cray EX software products are being upgraded in conjunction
+with SAT, refer to the [*HPE Cray EX System Software Getting Started Guide (S-8000)*](https://www.hpe.com/support/ex-S-8000)
+to determine which step to execute next.
+
+If no other HPE Cray EX software products are being upgraded at this time,
+execute the **SAT Post-Upgrade** procedures:
+
+- [Remove obsolete configuration file sections](#remove-obsolete-configuration-file-sections)
+- [SAT Logging](#sat-logging)
+
+## Post-Upgrade Cleanup Procedure
+
+1.  **Optional:** Remove the SAT release distribution tar file and extracted directory.
+
+    ```screen
+    ncn-m001# rm sat-x.y.z.tar.gz
+    ncn-m001# rm -rf sat-x.y.z/
+    ```
+
+## Remove Obsolete Configuration File Sections
+
+### Prerequisites
+
+- The [Upgrade the System Admin Toolkit Product Stream](#upgrade-the-system-admin-toolkit-product-stream)
+  procedure has been successfully completed.
+
+### Procedure
+
+After upgrading SAT, if using the configuration file from a previous version, there may be
+configuration file sections no longer used in the new version. For example, when upgrading
+from Shasta 1.4 to Shasta 1.5, the `[redfish]` configuration file section is no longer used.
+In that case, the following warning may appear upon running `sat` commands.
+
+```screen
+WARNING: Ignoring unknown section 'redfish' in config file.
+```
+
+Remove the `[redfish]` section from `/root/.config/sat/sat.toml` to resolve the warning.
+
+```screen
+[redfish]
+username = "admin"
+password = "adminpass"
+```
+
+Repeat this process for any configuration file sections for which there are "unknown section" warnings.
+
+## SAT Logging
+
+As of SAT version 2.2, some command output that was previously printed to `stdout`
+is now logged to `stderr`. These messages are logged at the `INFO` level. The
+default logging threshold was changed from `WARNING` to `INFO` to accommodate
+this logging change. Additionally, some messages previously logged at the `INFO`
+are now logged at the `DEBUG` level.
+
+These changes take effect automatically. However, if the default output threshold
+has been manually set in `~/.config/sat/sat.toml`, it should be changed to ensure
+that important output is shown in the terminal.
+
+### Update Configuration
+
+In the following example, the stderr log level, `logging.stderr_level`, is set to
+`WARNING`, which will exclude `INFO`-level logging from terminal output.
+
+```screen
+ncn-m001:~ # grep -A 3 logging ~/.config/sat/sat.toml
+[logging]
+...
+stderr_level = "WARNING"
+```
+
+To enable the new default behavior, comment this line out, delete it, or set
+the value to "INFO".
+
+If `logging.stderr_level` is commented out, its value will not affect logging
+behavior. However, it may be helpful set its value to `INFO` as a reminder of
+the new default behavior.
+
+### Affected Commands
+
+The following commands trigger messages that have been changed from `stdout`
+print calls to `INFO`-level (or `WARNING`- or `ERROR`-level) log messages:
+
+```
+sat bootsys --stage shutdown --stage session-checks
+sat sensors
+```
+
+The following commands trigger messages that have been changed from `INFO`-level
+log messages to `DEBUG`-level log messages:
+
+```
+sat nid2xname
+sat xname2nid
+sat swap
+```

--- a/docs/cne_install.md
+++ b/docs/cne_install.md
@@ -18,13 +18,13 @@ for detailed information about `cne-install` and its options.
 
 - CSM is installed and verified.
 - There must be at least 2 gigabytes of free space on the manager NCN on which
-the procedure is run.
+  the procedure is run.
 
 ### Notes on the Procedures
 
 - Ellipses (`...`) in shell output indicate omitted lines.
 - In the examples below, replace `x.y.z` with the version of the SAT product stream
-being upgraded.
+  being upgraded.
 - 'manager' and 'master' are used interchangeably in the steps below.
 
 ### Pre-Upgrade Procedure
@@ -50,7 +50,7 @@ being upgraded.
 1. Run the CNE installer.
 
      - If you are upgrading SAT along with other supported products, run the
-following command.
+       following command.
 
        ```screen
        ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH -bpc BOOTPREP_CONFIG_CN \
@@ -116,7 +116,7 @@ execute the **SAT Post-Upgrade** procedures:
 ### Prerequisites
 
 - The [Upgrade the System Admin Toolkit Product Stream](#upgrade-the-system-admin-toolkit-product-stream)
-procedure has been successfully completed.
+  procedure has been successfully completed.
 
 ### Procedure
 

--- a/docs/cne_install.md
+++ b/docs/cne_install.md
@@ -52,22 +52,22 @@ being upgraded.
      - If you are upgrading SAT along with other supported products, run the
 following command.
 
-     ```screen
-     ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH -bpc BOOTPREP_CONFIG_CN \
-         -bpn BOOTPREP_CONFIG_NCN
-     ```
+       ```screen
+       ncn-m001# cne-install -m MEDIA_DIR install -B WORKING_BRANCH -bpc BOOTPREP_CONFIG_CN \
+           -bpn BOOTPREP_CONFIG_NCN
+       ```
 
-     The `cne-install` command will use the provided `BOOTPREP_CONFIG_CN` and
-     `BOOTPREP_CONFIG_NCN` files for the run.
+       The `cne-install` command will use the provided `BOOTPREP_CONFIG_CN` and
+       `BOOTPREP_CONFIG_NCN` files for the run.
 
      - If you are upgrading SAT alone, run the following commands.
 
-     ```screen
-     ncn-m001# cne-install -m MEDIA_DIR install -B '{{product_type}}-{{version_x_y_z}}' /
-         -bpn BOOTPREP_CONFIG_NCN -e update_working_branches
-     ncn-m001# cne-install -m MEDIA_DIR install -B '{{product_type}}-{{version_x_y_z}}' /
-         -bpn BOOTPREP_CONFIG_NCN -b sat_bootprep_ncn -e ncn_personalization
-     ```
+       ```screen
+       ncn-m001# cne-install -m MEDIA_DIR install -B '{{product_type}}-{{version_x_y_z}}' \
+           -bpn BOOTPREP_CONFIG_NCN -e update_working_branches
+       ncn-m001# cne-install -m MEDIA_DIR install -B '{{product_type}}-{{version_x_y_z}}' \
+           -bpn BOOTPREP_CONFIG_NCN -b sat_bootprep_ncn -e ncn_personalization
+       ```
 
 1. **Optional:** Stop the typescript.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,8 +24,8 @@ the default.
     In SAT 2.4 and newer, you can instead upgrade the product stream by using the
     Compute Node Environment (CNE) installer. It is recommended that you upgrade
     SAT with the CNE installer because the process is both automated and logged
-    to help you save time. See [SAT Upgrade with CNE
-    Installer](cne_install.md) for more information.
+    to help you save time. See [SAT Upgrade with CNE Installer](cne_install.md)
+    for more information.
 
 ### Pre-Installation Procedure
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ the default.
     Compute Node Environment (CNE) installer. It is recommended that you upgrade
     SAT with the CNE installer because the process is both automated and logged
     to help you save time. See [SAT Upgrade with CNE
-    Installer](cne-install.md#cne-installer) for more information.
+    Installer](cne-install.md) for more information.
 
 ### Pre-Installation Procedure
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ the default.
     Compute Node Environment (CNE) installer. It is recommended that you upgrade
     SAT with the CNE installer because the process is both automated and logged
     to help you save time. See [SAT Upgrade with CNE
-    Installer](cne-install.md) for more information.
+    Installer](cne_install.md) for more information.
 
 ### Pre-Installation Procedure
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,6 @@ stream.
 ### Prerequisites
 
 - CSM is installed and verified.
-- cray-product-catalog is running.
 - There must be at least 2 gigabytes of free space on the manager NCN on which the
   procedure is run.
 
@@ -19,9 +18,13 @@ stream.
   being installed.
 - 'manager' and 'master' are used interchangeably in the steps below.
 - To upgrade SAT, execute the pre-installation, installation, and post-installation
-  procedures for a newer distribution. The newly installed version will become
-  the default.
-    In SAT 2.4 and newer, you can instead upgrade the product stream by using the Compute Node Environment (CNE) installer. It is recommended that you upgrade SAT with the CNE installer because the process is both automated and logged to help you save time. See [SAT Upgrade with CNE Installer](cne-install.md#cne-installer) for more information.
+procedures for a newer distribution. The newly installed version will become
+the default.
+    In SAT 2.4 and newer, you can instead upgrade the product stream by using the
+    Compute Node Environment (CNE) installer. It is recommended that you upgrade
+    SAT with the CNE installer because the process is both automated and logged
+    to help you save time. See [SAT Upgrade with CNE
+    Installer](cne-install.md#cne-installer) for more information.
 
 ### Pre-Installation Procedure
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,6 +21,7 @@ stream.
 - To upgrade SAT, execute the pre-installation, installation, and post-installation
   procedures for a newer distribution. The newly installed version will become
   the default.
+    In SAT 2.4 and newer, you can instead upgrade the product stream by using the Compute Node Environment (CNE) installer. It is recommended that you upgrade SAT with the CNE installer because the process is both automated and logged to help you save time. See [SAT Upgrade with CNE Installer](cne-install.md#cne-installer) for more information.
 
 ### Pre-Installation Procedure
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,6 +20,7 @@ stream.
 - To upgrade SAT, execute the pre-installation, installation, and post-installation
 procedures for a newer distribution. The newly installed version will become
 the default.
+
     In SAT 2.4 and newer, you can instead upgrade the product stream by using the
     Compute Node Environment (CNE) installer. It is recommended that you upgrade
     SAT with the CNE installer because the process is both automated and logged

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,8 +18,8 @@ stream.
   being installed.
 - 'manager' and 'master' are used interchangeably in the steps below.
 - To upgrade SAT, execute the pre-installation, installation, and post-installation
-procedures for a newer distribution. The newly installed version will become
-the default.
+  procedures for a newer distribution. The newly installed version will become
+  the default.
 
     In SAT 2.4 and newer, you can instead upgrade the product stream by using the
     Compute Node Environment (CNE) installer. It is recommended that you upgrade
@@ -116,7 +116,8 @@ If performing an upgrade, execute the **SAT Post-Upgrade** procedures:
 - [SAT Logging](#sat-logging)
 - [Set System Revision Information](#set-system-revision-information)
 
-**NOTE:** The **Set System Revision Information** procedure is **not required** after upgrading from SAT 2.1 or later.
+**NOTE:** The **Set System Revision Information** procedure is **not required**
+after upgrading from SAT 2.1 or later.
 
 ## Perform NCN Personalization
 


### PR DESCRIPTION
## Summary and Scope

I added information about using the new CNE installer (`cne-install`) to upgrade SAT. This is the recommended method for upgrading SAT in Papaya, but the manual upgrade method does still work. The CNE installer cannot complete SAT installs in Papaya.

I chose not to include the upgrade process as part of the `install.md` file to simplify things. If the information was in this file, users would look there for three different processes (installing SAT, upgrading SAT manually, and upgrading SAT with cne-install). I think that would be too much information in one place and too much jumping around between the sub-processes.

## Issues and Related PRs

* Resolves [STP-3310](https://jira-pro.its.hpecorp.net:8443/browse/STP-3310)
* Change will also be needed in `release/2.4`

## Testing

Lint check, style check, spell check.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

