### PR TITLE
STP-3353: Add info on changing BOS version to integration branch

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -72,6 +72,7 @@ subcommands
 subdomain
 sublicense
 subrole
+uncomment
 versioned
 # The spell checker complains about legacy Shasta version numbers (vX.Y) when
 # they end in a period, for example "In 2020 HPE released Shasta v1.4.1."

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,8 +45,8 @@
 
 ## [SAT Usage](usage/README.md)
 
-- [SAT Bootprep](usage/sat-bootprep.md)
-- [Change the BOS Version](usage/change-bos-version.md)
+- [SAT Bootprep](usage/sat_bootprep.md)
+- [Change the BOS Version](usage/change_bos_version.md)
 
 ## [SAT Release Notes](release_notes.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,12 +43,10 @@
 - [SAT Kibana Dashboards](dashboards/SAT_Kibana_Dashboards.md)
 - [SAT Grafana Dashboards](dashboards/SAT_Grafana_Dashboards.md)
 
-## [SAT Bootprep](sat_bootprep.md)
+## [SAT Usage](usage/README.md)
 
-- [SAT Bootprep vs SAT Bootsys](sat_bootprep.md#sat-bootprep-vs-sat-bootsys)
-- [Editing a Bootprep Input File](sat_bootprep.md#editing-a-bootprep-input-file)
-- [Example Bootprep Input Files](sat_bootprep.md#example-bootprep-input-files)
-- [Viewing Built-in Generated Documentation](sat_bootprep.md#viewing-built-in-generated-documentation)
+- [SAT Bootprep](usage/sat-bootprep.md)
+- [Change the BOS Version](usage/change-bos-version.md)
 
 ## [SAT Release Notes](release_notes.md)
 

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,0 +1,4 @@
+# SAT Usage
+
+- [SAT Bootprep](sat-bootprep.md)
+- [Change the BOS Version](change-bos-version.md)

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,4 +1,4 @@
 # SAT Usage
 
-- [SAT Bootprep](sat-bootprep.md)
-- [Change the BOS Version](change-bos-version.md)
+- [SAT Bootprep](sat_bootprep.md)
+- [Change the BOS Version](change_bos_version.md)

--- a/docs/usage/change_bos_version.md
+++ b/docs/usage/change_bos_version.md
@@ -16,10 +16,10 @@ config file.
    # api_version = "v1"
    ```
 
-   In this example, SAT is using the default BOS version `"v1"`.
+   In this example, SAT is using BOS version `"v1"`.
 
-2. Uncomment the line specifying the `api_version`, and set it to the version
-   desired (for example, `"v2"`).
+2. Change the line specifying the `api_version` to the BOS version desired (for
+   example, `"v2"`).
 
    ```screen
    [bos]

--- a/docs/usage/change_bos_version.md
+++ b/docs/usage/change_bos_version.md
@@ -1,31 +1,44 @@
 # Change the BOS Version
 
-By default, SAT uses BOS `v1`. You can select the BOS version to use for
-individual commands with the `--bos-version` option. For more information on
-this option, see the man page for a specific command.
+By default, SAT uses Boot Orchestration Service (BOS) version one. You can
+select the BOS version to use for individual commands with the `--bos-version`
+option. For more information on this option, see the man page for a specific
+command.
 
-You can also configure the BOS version to use in the SAT config file.
-Do this under the `api_version` setting in the `bos` section of the
-config file.
+You can also configure the BOS version to use in the SAT config file. Do this
+under the `api_version` setting in the `bos` section of the config file. If
+the system is using an existing SAT config file from an older version of SAT,
+the `bos` section might not exist. In that case, add the `bos` section with the
+BOS version desired in the `api_version` setting.
 
 1. Find the SAT config file at `~/.config/sat/sat.toml`, and look for a section
    like this:
 
    ```screen
    [bos]
-   # api_version = "v1"
+   api_version = "v1"
    ```
 
    In this example, SAT is using BOS version `"v1"`.
 
-2. Change the line specifying the `api_version` to the BOS version desired (for
+1. Change the line specifying the `api_version` to the BOS version desired (for
    example, `"v2"`).
+
+   ```screen
+   [bos]
+   api_version = "v2"
+   ```
+
+1. If applicable, uncomment the `api_version` line.
+
+   If the system is using an existing SAT config file from a recent version of
+   SAT, the `api_version` line might be commented out like this:
 
    ```screen
    [bos]
    # api_version = "v2"
    ```
 
-If the system is using an existing SAT config file from an older version of
-SAT, the `bos` section might not exist. Instead, you should add the `bos`
-section with the BOS version desired in the `api_version` setting.
+   If the line is commented out, SAT will still use the default BOS
+   version. To ensure a different BOS version is used, uncomment the
+   `api_version` line by removing `#` at the beginning of the line.

--- a/docs/usage/change_bos_version.md
+++ b/docs/usage/change_bos_version.md
@@ -1,0 +1,31 @@
+# Change the BOS Version
+
+By default, SAT uses BOS `v1`. You can select the BOS version to use for
+individual commands with the `--bos-version` option. For more information on
+this option, see the man page for a specific command.
+
+You can also configure the BOS version to use in the SAT config file.
+Do this under the `api_version` setting in the `bos` section of the
+config file.
+
+1. Find the SAT config file at `~/.config/sat/sat.toml`, and look for a section
+   like this:
+
+   ```screen
+   [bos]
+   # api_version = "v1"
+   ```
+
+   In this example, SAT is using the default BOS version `"v1"`.
+
+2. Uncomment the line specifying the `api_version`, and set it to the version
+   desired (for example, `"v2"`).
+
+   ```screen
+   [bos]
+   # api_version = "v2"
+   ```
+
+If the system is using an existing SAT config file from an older version of
+SAT, the `bos` section might not exist. Instead, you should add the `bos`
+section with the BOS version desired in the `api_version` setting.

--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -505,6 +505,7 @@ configurations:
       name: cpe
       version: "{{cpe.version}}"
       branch: integration-{{cpe.version}}
+
 images:
 - name: "{{base.name}}"
   ref_name: base_cos_image
@@ -513,6 +514,7 @@ images:
       name: cos
       type: recipe
       version: "{{cos.version}}"
+
 - name: compute-{{base.name}}
   ref_name: compute_image
   base:
@@ -520,6 +522,7 @@ images:
   configuration: compute-{{recipe.version}}
   configuration_group_names:
   - Compute
+
 session_templates:
 - name: compute-{{recipe.version}}
   image:

--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -505,7 +505,6 @@ configurations:
       name: cpe
       version: "{{cpe.version}}"
       branch: integration-{{cpe.version}}
-
 images:
 - name: "{{base.name}}"
   ref_name: base_cos_image
@@ -514,7 +513,6 @@ images:
       name: cos
       type: recipe
       version: "{{cos.version}}"
-
 - name: compute-{{base.name}}
   ref_name: compute_image
   base:
@@ -522,7 +520,6 @@ images:
   configuration: compute-{{recipe.version}}
   configuration_group_names:
   - Compute
-
 session_templates:
 - name: compute-{{recipe.version}}
   image:


### PR DESCRIPTION
## Summary and Scope

Added information on changing the BOS version. You can select the BOS version to use for individual commands with the `--bos-version` option. You can also configure the BOS version to use in the SAT config file.

## Issues and Related PRs

* Resolves [STP-3353](https://jira-pro.its.hpecorp.net:8443/browse/STP-3353)
* Change will also be needed in `release/2.4`

## Testing

Spell check and lint check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

