### PR TITLE
CASMTRIAGE-4503: Add some helpful bootprep procedures

### DIFF
--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -551,6 +551,167 @@ Variables](#viewing-hpc-csm-software-recipe-variables). Then, access the files i
 ncn-m001# ls bootprep/
 ```
 
+### Editing Default Bootprep Input File Branches
+
+For products requiring site-specific changes on a working branch of VCS, the default
+bootprep input files refer to a particular branch of that product's configuration
+management repository. This makes assumptions about the names of the VCS branches
+and it is important to ensure that the bootprep input files are consistent with
+these branches.
+
+For example, in the default `management-bootprep.yaml` bootprep input file,
+the COS product's CFS configuration layer is defined as follows.
+
+```yaml
+- name: cos-ncn-integration-{{cos.version}}
+  playbook: ncn.yml
+  product:
+    name: cos
+    version: "{{cos.version}}"
+    branch: integration-{{cos.version}}
+```
+
+This is making the assumption that site-specific Ansible configuration changes
+for the COS product in VCS are stored in a branch named
+`integration-{{cos.version}}`, that is if the version being installed were COS
+2.4.99, then `sat bootprep` will be looking for a branch named `integration-2.4.99`
+from which to create CFS configuration layers.
+
+It is still possible to create VCS working branches that are not these default
+names. A simple example of this is using `cne-install` to update working VCS
+branches. If using `cne-install` to update working VCS branches, (namely in
+the `update_working_branches` stage), you will have created or updated the
+branches specified by the `-B WORKING_BRANCH` command-line option. For
+example, consider the following `cne-install` command.
+
+```screen
+ncn-m001# ./cne-install install \
+    -B integration \
+    -s deploy_products \
+    -e update_working_branches
+```
+
+Products that were installed with this `cne-install` invocation would be using
+the working branch `integration` for site-specific changes to VCS.
+The branch specified by the `-B` option must match the branch specified in the
+bootprep input file. For example, to use the branch "integration" for COS rather
+than `integration-{{cos.version}}`, edit the bootprep input file so it reads:
+
+```yaml
+- name: cos-ncn-integration-{{cos.version}}
+  playbook: ncn.yml
+  product:
+    name: cos
+    version: "{{cos.version}}"
+    branch: integration
+```
+
+Prior to running `sat bootprep` HPE recommends to read the input file and to pay
+special attention to the `branch` parameters.
+
+### Editing Default Bootprep Management CFS Configuration Names
+
+The default bootprep input file for management CFS configurations,
+`management-bootprep.yaml`, creates configurations whose names are specified
+in the input file. For example, in the bootprep input files that are included
+in the ``22.11`` recipe, these configurations are named:
+
+- `ncn-personalization`
+- `ncn-image-customization`
+
+These default names may be suitable, but it is possible to name them something
+else as well. `sat bootprep` will create whatever configurations are specified
+in the input file. For example, to create a NCN node personalization
+configuration named `ncn-personalization-test`, edit the file as follows.
+
+```yaml
+configurations:
+- name: ncn-personalization-test
+  layers:
+  ...
+```
+
+In the case of management configurations, use `sat status` to identify the
+current "Desired Config" for each of the management nodes.
+
+```screen
+ncn-m001# sat status --fields xname,role,subrole,desiredconfig --filter role=management
++----------------+------------+---------+---------------------+
+| xname          | Role       | SubRole | Desired Config      |
++----------------+------------+---------+---------------------+
+| x3000c0s1b0n0  | Management | Master  | ncn-personalization |
+| x3000c0s3b0n0  | Management | Master  | ncn-personalization |
+| x3000c0s5b0n0  | Management | Master  | ncn-personalization |
+| x3000c0s7b0n0  | Management | Worker  | ncn-personalization |
+| x3000c0s9b0n0  | Management | Worker  | ncn-personalization |
+| x3000c0s11b0n0 | Management | Worker  | ncn-personalization |
+| x3000c0s13b0n0 | Management | Worker  | ncn-personalization |
+| x3000c0s17b0n0 | Management | Storage | ncn-personalization |
+| x3000c0s19b0n0 | Management | Storage | ncn-personalization |
+| x3000c0s21b0n0 | Management | Storage | ncn-personalization |
+| x3000c0s25b0n0 | Management | Worker  | ncn-personalization |
++----------------+------------+---------+---------------------+
+```
+
+To overwrite that configuration using `sat bootprep`, ensure the bootprep input
+file is specifying to create a configuration named `ncn-personalization`. To
+create a different configuration, ensure the bootprep input file is *not*
+specifying to create a configuration named `ncn-personalization`.
+
+### Upgrading a Single Product and Overriding its Version
+
+When working with a given software recipe, it may be necessary to upgrade a
+single product past the version given in the software recipe, but use the other
+product versions contained in that recipe.
+
+To upgrade the product, refer to the product's specific upgrade instructions.
+
+Once the product has been upgraded, you will need to override its version in
+subsequent runs of `sat bootprep`.
+
+This example details how to use all the product versions from the `22.11`
+software recipe, except override the COS product to version `2.4.199`, and
+shows the creation of CFS configurations in `management-bootprep.yaml`.
+
+1. Ensure you have a local copy of the default bootprep input files
+   (see: [Accessing Default Bootprep Input Files](#accessing-default-bootprep-input-files)).
+
+1. Start by navigating to the directory containing the `product_vars.yaml` file.
+   This example shows the recipe distribution being located in `/mnt/admin/`.
+
+   ```screen
+   ncn-m001# pwd
+   /mnt/admin/hpc-csm-software-recipe-22.11.0/vcs
+   ```
+
+1. Edit `product_vars.yaml`
+
+   ```screen
+   ncn-m001# vim product_vars.yaml
+   ```
+
+1. Check the edited version of `product_vars.yaml`.
+
+   ```screen
+   ncn-m001# grep -A1 cos: `product_vars.yaml`:
+   cos:
+     version: 2.4.199
+   ```
+
+1. When running `sat bootprep`, use the `--vars-file` to override the version.
+
+   **Note:** This command must be run from the directory containing `product_vars.yaml`,
+   and `product_vars.yaml` *must* be specified using `--vars-file`, it is not sufficient
+   to just edit the file.
+
+   **Note:** This example is specific to creating the configurations defined in
+   `management-bootprep.yaml`. Review what configurations, images and/or session templates
+   you intend to create by viewing the input file.
+
+   ```screen
+   ncn-m001# sat bootprep run --vars-file product_vars.yaml bootprep/management-bootprep.yaml
+   ```
+
 ### Generating an Example Bootprep Input File
 
 **Note:** The `sat bootprep generate-example` command was not updated for


### PR DESCRIPTION
This commit adds three procedures to the SAT bootprep usage guide.

First, add a procedure explaining how to edit branch names in the input file. This could be useful if using working branches other than the default branches provided by the software recipe build.

Second, add a procedure explaining how to look up what configuration is used and how to rename it.

Finally, add a procedure explaining how to override a product's version via the `product_vars.yaml` file.

Test Description:
Ran all checks as a part of pull request process.

(cherry picked from commit 9e97ff424d58ac3c0040ea5028f902b0cec0ad84)

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

