### PR TITLE
STP-3305: Update links to Getting Started Guide in integration

### DIFF
--- a/docs/cne_install.md
+++ b/docs/cne_install.md
@@ -5,14 +5,14 @@
 Describes how to upgrade the System Admin Toolkit (SAT) product
 stream by using the Compute Node Environment (CNE) installer (`cne-install`).
 The CNE installer can be used only for upgrades and not for fresh installations.
-See [Install the System Admin Toolkit Product Stream](install.md) for
-installation instructions.
+For installation instructions, see [Install the System Admin Toolkit Product
+Stream](install.md).
 
 Upgrading SAT with `cne-install` is recommended because the process is both
 automated and logged to help you save time. The CNE installer can be used to
-upgrade SAT alone or with other supported products. Refer to the [*HPE Cray EX
-System Software Getting Started Guide (S-8000)*](<https://www.hpe.com/support/ex-S-8000>)
-for detailed information about `cne-install` and its options.
+upgrade SAT alone or with other supported products. For more information
+on `cne-install` and its options, refer to the [*HPE Cray EX System Software
+Getting Started Guide (S-8000)*](<https://www.hpe.com/support/ex-S-8000>).
 
 ### Prerequisites
 
@@ -72,7 +72,7 @@ for detailed information about `cne-install` and its options.
 1. **Optional:** Stop the typescript.
 
    **NOTE**: This step can be skipped if you wish to use the same typescript
-   for the remainder of the SAT upgrade. See [Next Steps](#next-steps).
+   for the remainder of the SAT upgrade (see [Next Steps](#next-steps)).
 
    ```screen
    ncn-m001# exit

--- a/docs/dashboards/SAT_Grafana_Dashboards.md
+++ b/docs/dashboards/SAT_Grafana_Dashboards.md
@@ -22,11 +22,11 @@ That command will produce the following output, for example:
 
 This would result in the address for Grafana being `https://sma-grafana.cmn.EXAMPLE_DOMAIN.com`
 
-For additional details about how to access the Grafana Dashboards refer to *Access the Grafana Monitoring UI* in the
+For more information on accessing the Grafana Dashboards, refer to **Access the Grafana Monitoring UI** in the
 SMA product documentation.
 
-For more information about the interpretation of metrics for the SAT Grafana Dashboards refer to *Fabric Telemetry
-Kafka Topics* in the SMA product documentation.
+For more information on the interpretation of metrics for the SAT Grafana Dashboards, refer to "Fabric Telemetry
+Kafka Topics" in the SMA product documentation.
 
 ## Navigate SAT Grafana Dashboards
 
@@ -54,7 +54,7 @@ The value of the **Interval** option sets the time resolution of the received te
 histogram, with the available telemetry in an interval of time going into a "bucket" and averaging out to a single
 point on the chart or table. The special value *auto* will choose an interval based on the time range selected.
 
-For additional information, refer to [Grafana Templates and Variables](https://grafana.com/docs/grafana/latest/reference/templating/#interval-variables).
+For more information, refer to [Grafana Templates and Variables](https://grafana.com/docs/grafana/latest/reference/templating/#interval-variables).
 
 The **Locations** option allows restriction of the telemetry shown by locations, either individual links or all links
 in a switch. The selection presented updates dynamically according to time range, except for the errors dashboard,
@@ -112,7 +112,7 @@ all port state events.
 
 ![Grafana Fabric RFC3635 Dashboard](../img/Grafana_rfc3635.png)
 
-For additional information on performance counters, refer to
+For more information on performance counters, refer to
 [Definitions of Managed Objects for the Ethernet-like Interface Types](https://tools.ietf.org/html/rfc3635),
 an Internet standards document.
 

--- a/docs/dashboards/SAT_Kibana_Dashboards.md
+++ b/docs/dashboards/SAT_Kibana_Dashboards.md
@@ -24,7 +24,7 @@ That command will produce the following output, for example:
 
 This would result in the address for Kibana being `https://sma-kibana.cmn.EXAMPLE_DOMAIN.com`
 
-For additional details about how to access the Kibana Dashboards refer to *View Logs Via Kibana* in the SMA product
+For more information on accessing the Kibana Dashboards, refer to **View Logs Via Kibana** in the SMA product
 documentation.
 
 Additional details about the AER, ATOM, Heartbeat, Kernel, MCE, and RAS Daemon Kibana Dashboards are included in this

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,9 +26,10 @@ are reported through Redfish.
 - [Grafana Fabric Port State Dashboard](dashboards/SAT_Grafana_Dashboards.md#grafana-fabric-port-state-dashboard)
 - [Grafana Fabric RFC3635 Dashboard](dashboards/SAT_Grafana_Dashboards.md#grafana-fabric-rfc3635-dashboard)
 
-In CSM 1.3 and newer, the `sat` command is automatically available on all the Kubernetes NCNs. See
-[SAT in CSM](#sat-in-csm) for more information. Older versions of CSM do not have the `sat` command automatically
-available, and SAT must be installed as a separate product.
+In CSM 1.3 and newer, the `sat` command is automatically available on all the
+Kubernetes NCNs. For more information, see [SAT in CSM](#sat-in-csm). Older
+versions of CSM do not have the `sat` command automatically available, and SAT
+must be installed as a separate product.
 
 ## System Admin Toolkit Command Overview
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -251,8 +251,8 @@ Python dependency versions.
 
 ### Bug Fixes
 
-Minor bug fixes were made in each of the repositories. For full change lists, see each
-repository’s `CHANGELOG.md` file.
+Minor bug fixes were made in each of the repositories. For full change lists,
+refer to each repository’s `CHANGELOG.md` file.
 
 The [known issues listed under the SAT 2.2 release](#known-issues-in-sat-22) were fixed.
 
@@ -336,8 +336,8 @@ To resolve, run `sat` in another directory.
 ### New `sat` Commands
 
 - `sat bootprep` automates the creation of CFS configurations, the build and
-  customization of IMS images, and the creation of BOS session templates. See
-  [SAT Bootprep](usage/sat_bootprep.md) for details.
+  customization of IMS images, and the creation of BOS session templates. For
+  more information, see [SAT Bootprep](usage/sat_bootprep.md).
 - `sat slscheck` performs a check for consistency between the System Layout
   Service (SLS) and the Hardware State Manager (HSM).
 - `sat bmccreds` provides a simple interface for interacting with the System
@@ -371,9 +371,9 @@ versions moving forward.
 Beginning with the 2.2 release, SAT now provides partial support for the
 uninstall and activation of the SAT product stream.
 
-See [Uninstall: Removing a Version of SAT](install.md#uninstall-removing-a-version-of-sat)
-and [Activate: Switching Between Versions](install.md#activate-switching-between-versions)
-for details.
+For more information, see [Uninstall: Removing a Version of
+SAT](install.md#uninstall-removing-a-version-of-sat) and [Activate: Switching
+Between Versions](install.md#activate-switching-between-versions).
 
 ### Improvements to `sat status`
 
@@ -406,7 +406,7 @@ mostly related to filtering command output. The following are some highlights:
 ### Default Log Level Changed
 
 The default log level for `stderr` has been changed from "WARNING" to "INFO". For
-details, see [SAT Logging](install.md#sat-logging).
+more information, see [SAT Logging](install.md#sat-logging).
 
 ### More Granular Log Level Configuration Options
 
@@ -444,7 +444,7 @@ such as `awk`, `less`, and `more`.
 ### Configurable HTTP Timeout
 
 A new `sat` option has been added to configure the HTTP timeout length for
-requests to the API gateway. See `sat-man sat` for details.
+requests to the API gateway. For more information, refer to `sat-man sat`.
 
 ### `sat bootsys` Improvements
 
@@ -497,7 +497,7 @@ tests by running them in the container.
 ### Bug Fixes
 
 Minor bug fixes were made in `cray-sat` and in `cray-sat-podman`. For full change lists,
-see each repository's `CHANGELOG.md` file.
+refer to each repository's `CHANGELOG.md` file.
 
 ## Summary of SAT Changes in Shasta v1.5
 
@@ -556,7 +556,7 @@ replaced by functionality from the Slingshot Topology Tool (STT) in the
 fabric manager pod.
 
 The Redfish username and password command line options and config file options
-have been removed. For further instructions, see [Remove Obsolete Configuration
+have been removed. For more information, see [Remove Obsolete Configuration
 File Sections](install.md#remove-obsolete-configuration-file-sections).
 
 ### Additional Fields in `sat setrev` and `sat showrev`
@@ -701,8 +701,8 @@ information, including system name, site name, serial number, install date, and
 system type. Since the information is stored in S3, it will now be consistent
 regardless of the node on which `sat` is executed.
 
-As a result of this change, S3 credentials must be configured for SAT. For detailed
-instructions, see [Generate SAT S3 Credentials](install.md#generate-sat-s3-credentials).
+As a result of this change, S3 credentials must be configured for SAT. For more
+information, see [Generate SAT S3 Credentials](install.md#generate-sat-s3-credentials).
 
 ### Product Version Information Shown by `sat showrev`
 
@@ -788,7 +788,7 @@ command will be removed in a future release.
 
 The `sat bootsys` command now has multiple stages for both the `boot` and
 `shutdown` actions. Please refer to the "System Power On Procedures" and "System
-Power Off Procedures" sections of the Cray Shasta Administration Guide (S-8001)
+Power Off Procedures" sections of the *Cray Shasta Administration Guide (S-8001)*
 for more details on using this command in the context of a full system power off
 and power on.
 
@@ -814,6 +814,7 @@ This version of the `sat` CLI contained the following commands:
 - `swap`
 - `switch`
 
-See the [System Admin Toolkit Command Overview](introduction.md#system-admin-toolkit-command-overview)
-and the table of commands in the [SAT Authentication](install.md#sat-authentication) section
-of this document for more details on each of these commands.
+For more information on each of these commands, see the [System Admin Toolkit Command
+Overview](introduction.md#system-admin-toolkit-command-overview) and the table
+of commands in the [SAT Authentication](install.md#sat-authentication) section
+of this document.

--- a/docs/usage/change_bos_version.md
+++ b/docs/usage/change_bos_version.md
@@ -2,7 +2,7 @@
 
 By default, SAT uses Boot Orchestration Service (BOS) version one. You can
 select the BOS version to use for individual commands with the `--bos-version`
-option. For more information on this option, see the man page for a specific
+option. For more information on this option, refer to the man page for a specific
 command.
 
 You can also configure the BOS version to use in the SAT config file. Do this

--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -56,7 +56,7 @@ The `sat bootprep run` command validates the schema version specified
 in the input file. The command also makes sure that the schema version
 of the input file is compatible with the schema version understood by the
 current version of `sat bootprep`. For more information on schema version
-validation, see the `schema_version` property description in the bootprep
+validation, refer to the `schema_version` property description in the bootprep
 input file schema. For more information on viewing the bootprep input file
 schema in either raw form or user-friendly HTML form, see [Viewing the Exact
 Schema Specification](#viewing-the-exact-schema-specification) or
@@ -246,7 +246,7 @@ which are optional:
 
 As mentioned above, the parameters under `bos_parameters` are passed through
 directly to BOS. For more information on the properties of a BOS boot set,
-refer to the section **BOS Session Templates** in the [*Cray
+refer to **BOS Session Templates** in the [*Cray
 System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 
 Here is an example of a BOS session template that refers to an existing IMS
@@ -340,7 +340,7 @@ In addition, Python string methods can be called on the string variables.
 HPC CSM Software Recipe variables are available, and you can use them in the
 values of the keys listed above. A listing of the available variables and their
 values can be viewed by running `sat bootprep list-vars`. For more information
-on options that may be used with the `list-vars` subcommand, see the man page
+on options that may be used with the `list-vars` subcommand, refer to the man page
 for the `sat bootprep` subcommand.
 
 #### HPC CSM Software Recipe Variable Substitution Example
@@ -387,9 +387,9 @@ configurations:
 ### Dynamic Variable Substitutions
 
 Additional variables are available besides the product version variables
-provided by the HPC CSM Software Recipe. (See [HPC CSM Software Recipe Variable
-Substitutions](#hpc-csm-software-recipe-variable-substitutions) for more
-information.) These additional variables are dynamic because their values are
+provided by the HPC CSM Software Recipe. (For more information, see [HPC
+CSM Software Recipe Variable Substitutions](#hpc-csm-software-recipe-variable-substitutions).)
+These additional variables are dynamic because their values are
 determined at run-time based on the context in which they appear. Available
 dynamic variables include the following:
 


### PR DESCRIPTION
## Summary and Scope

A new vanity URL is being used for the Papaya version of the Getting Started Guide. This URL has been updated throughout the SAT documentation. The new URL will not be live until the Papaya version of the Getting Started Guide is posted to the HPE Support Center with the official release. The new link is expected to break until then.

I also tried to create more consistency in how references and links are presented throughout. Here are my team's recommended guidelines:

- Use "refer to" for links/references outside sat-docs
- Use "see" for links/references within sat-docs
- Italicize guide titles we refer to
- Put section names of other guides we refer to in quotes
- Put topics names of other guides we refer to in bold

For CSM, it's ok to provide a general link to the documentation since it's open source. However, we want to avoid linking to specific sections since the location and name of these sections might change. For now, it's better to only list the name of the sections users want so that they can search for them within the CSM documentation.

## Issues and Related PRs

* Resolves [STP-3305](https://jira-pro.its.hpecorp.net:8443/browse/STP-3305)
* Change will also be needed in `release/2.4`

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable