### PR TITLE
CRAYSAT-1610: Update name of management NCN CFS config

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -491,13 +491,13 @@ SAT.
    ```screen
    ====> Updating CFS configuration(s)
    INFO: Querying CFS configurations for the following NCNs: x3000c0s1b0n0, ..., x3000c0s9b0n0
-   INFO: Found configuration "ncn-personalization" for component x3000c0s1b0n0
+   INFO: Found configuration "management-23.03" for component x3000c0s1b0n0
    ...
-   INFO: Found configuration "ncn-personalization" for component x3000c0s9b0n0
+   INFO: Found configuration "management-23.03" for component x3000c0s9b0n0
    ...
    INFO: No layer with repo path /vcs/cray/sat-config-management.git and playbook sat-ncn.yml found.
    INFO: Adding a layer with repo path /vcs/cray/sat-config-management.git and playbook sat-ncn.yml to the end.
-   INFO: Successfully saved CFS configuration "ncn-personalization"
+   INFO: Successfully saved CFS configuration "management-23.03"
    INFO: Successfully saved 1 changed CFS configurations.
    ====> Completed CFS configuration(s)
    ====> Cleaning up install dependencies
@@ -509,14 +509,14 @@ SAT.
    ```screen
    ====> Updating CFS configuration(s)
    INFO: Querying CFS configurations for the following NCNs: x3000c0s1b0n0, ..., x3000c0s9b0n0
-   INFO: Found configuration "ncn-personalization" for component x3000c0s1b0n0
+   INFO: Found configuration "management-23.03" for component x3000c0s1b0n0
    ...
-   INFO: Found configuration "ncn-personalization" for component x3000c0s9b0n0
+   INFO: Found configuration "management-23.03" for component x3000c0s9b0n0
    ...
    INFO: Updating existing layer with repo path /vcs/cray/sat-config-management.git and playbook sat-ncn.yml
    INFO: Property "commit" of layer with repo path /vcs/cray/sat-config-management.git and playbook sat-ncn.yml updated from 01ae28c92b9b4740e9e0e01ae01216c6c2d89a65 to bcbd6db0803cc4137c7558df9546b0faab303cbd
    INFO: Property "name" of layer with repo path /vcs/cray/sat-config-management.git and playbook sat-ncn.yml updated from sat-2.2.16 to sat-sat-ncn-bcbd6db-20220608T170152
-   INFO: Successfully saved CFS configuration "ncn-personalization"
+   INFO: Successfully saved CFS configuration "management-23.03"
    INFO: Successfully saved 1 changed CFS configurations.
    ====> Completed CFS configuration(s)
    ====> Cleaning up install dependencies
@@ -596,7 +596,7 @@ execute the following steps to ensure the modified CFS configuration is re-appli
    to be applied to the management NCNs.
 
    ```screen
-   ncn-m001# export CFS_CONFIG_NAME="ncn-personalization"
+   ncn-m001# export CFS_CONFIG_NAME="management-23.03"
    ```
 
    Note: If the [Update Active CFS Configuration](#update-active-cfs-configuration)
@@ -605,7 +605,7 @@ execute the following steps to ensure the modified CFS configuration is re-appli
    were modified, any one of them can be used in this procedure.
 
    ```screen
-   INFO: Successfully saved CFS configuration "ncn-personalization"
+   INFO: Successfully saved CFS configuration "management-23.03"
    ```
 
 1. Obtain the name of the CFS configuration layer for SAT and save it in an
@@ -909,14 +909,14 @@ This procedure can be used to downgrade the active version of SAT.
      `sat showrev`.
    - Ensure that the SAT CFS configuration content exists as a layer in all CFS configurations that are
      associated with NCNs with the role "Management" and subrole "Master" (for example, the CFS configuration
-     `ncn-personalization`). Specifically, it will ensure that the layer refers to the version of SAT CFS
+     `management-23.03`). Specifically, it will ensure that the layer refers to the version of SAT CFS
      configuration content associated with the version of SAT being activated.
 
    ```screen
    ncn-m001# prodmgr activate sat 2.2.10
    Repository sat-2.2.10-sle-15sp2 is now the default in sat-sle-15sp2.
    Set sat-2.2.10 as active in product catalog.
-   Updated CFS configurations: [ncn-personalization]
+   Updated CFS configurations: [management-23.03]
    ```
 
 1. Verify that the chosen version is marked as active.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -161,7 +161,7 @@ to install SAT as a separate product stream. Any version of SAT installed as a s
   only available with the full SAT product stream.
 
 If the SAT product stream is not installed, there will be no configuration content for SAT in VCS. Therefore, CFS
-configurations that apply to NCNs (for example, `ncn-personalization`) should not include a SAT layer.
+configurations that apply to management NCNs (for example, `management-23.03`) should not include a SAT layer.
 
 The SAT configuration layer modifies the permissions of files left over from prior installations of SAT, so that the
 Keycloak username that authenticates to the API gateway cannot be read by users other than `root`. Specifically, it

--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -558,23 +558,21 @@ follows.
 
 ### Editing Default Management CFS Configuration Names
 
-The default bootprep input file for management CFS configurations
-(`management-bootprep.yaml`) creates configurations that have names specified
-within the input file. For example, in the bootprep input files included in the
-``22.11`` HPC CSM Software Recipe, the following configurations are named:
+The default bootprep input file for management NCNs (`management-bootprep.yaml`)
+uses the value `management-{{recipe.version}}` as the name of the CFS
+configuration. This uses a Jinja2 template to include the HPC CSM Software
+Recipe version in the name of the CFS configuration. For example, when `sat
+bootprep` is run against this file in HPC CSM Software Recipe version `23.03`, a
+configuration named `management-23.03` is created.
 
-- `ncn-personalization`
-- `ncn-image-customization`
-
-These default management CFS configuration names might be acceptable for your
-system. However, it is possible to create other names. `sat bootprep` creates
-whatever configurations are specified in the input file. For example, to
-create a NCN node personalization configuration named
-`ncn-personalization-test`, edit the file as follows.
+This default management CFS configuration name might be acceptable for your
+system. However, it is possible to use a different names. `sat bootprep` creates
+whatever configurations are specified in the input file. For example, to create
+a CFS configuration named `management-test`, edit the file as follows:
 
 ```yaml
 configurations:
-- name: ncn-personalization-test
+- name: management-test
   layers:
   ...
 ```
@@ -584,28 +582,28 @@ desired configuration for each of the management nodes.
 
 ```screen
 ncn-m001# sat status --fields xname,role,subrole,desiredconfig --filter role=management
-+----------------+------------+---------+---------------------+
-| xname          | Role       | SubRole | Desired Config      |
-+----------------+------------+---------+---------------------+
-| x3000c0s1b0n0  | Management | Master  | ncn-personalization |
-| x3000c0s3b0n0  | Management | Master  | ncn-personalization |
-| x3000c0s5b0n0  | Management | Master  | ncn-personalization |
-| x3000c0s7b0n0  | Management | Worker  | ncn-personalization |
-| x3000c0s9b0n0  | Management | Worker  | ncn-personalization |
-| x3000c0s11b0n0 | Management | Worker  | ncn-personalization |
-| x3000c0s13b0n0 | Management | Worker  | ncn-personalization |
-| x3000c0s17b0n0 | Management | Storage | ncn-personalization |
-| x3000c0s19b0n0 | Management | Storage | ncn-personalization |
-| x3000c0s21b0n0 | Management | Storage | ncn-personalization |
-| x3000c0s25b0n0 | Management | Worker  | ncn-personalization |
-+----------------+------------+---------+---------------------+
++----------------+------------+---------+------------------+
+| xname          | Role       | SubRole | Desired Config   |
++----------------+------------+---------+------------------+
+| x3000c0s1b0n0  | Management | Master  | management-23.03 |
+| x3000c0s3b0n0  | Management | Master  | management-23.03 |
+| x3000c0s5b0n0  | Management | Master  | management-23.03 |
+| x3000c0s7b0n0  | Management | Worker  | management-23.03 |
+| x3000c0s9b0n0  | Management | Worker  | management-23.03 |
+| x3000c0s11b0n0 | Management | Worker  | management-23.03 |
+| x3000c0s13b0n0 | Management | Worker  | management-23.03 |
+| x3000c0s17b0n0 | Management | Storage | management-23.03 |
+| x3000c0s19b0n0 | Management | Storage | management-23.03 |
+| x3000c0s21b0n0 | Management | Storage | management-23.03 |
+| x3000c0s25b0n0 | Management | Worker  | management-23.03 |
++----------------+------------+---------+------------------+
 ```
 
 To overwrite the desired configuration using `sat bootprep`, ensure the bootprep
 input file specifies to create a configuration with the same name
-(`ncn-personalization` in the example above). To create a different configuration,
+(`management-23.03` in the example above). To create a different configuration,
 ensure the bootprep input file specifies to create a configuration with a
-different name than the desired configuration (different than `ncn-personalization`
+different name than the desired configuration (different than `management-23.03`
 in the example above).
 
 ### Upgrading a Single Product and Overriding its Default Version


### PR DESCRIPTION

## Summary and Scope

Beginning with the Alice release of the HPC CSM Software Recipe, the management NCN CFS configuration will be named
`management-{{recipe.version}}` where `recipe.version` is the version of the HPC CSM Software Recipe (currently planned to be 23.03). This single configuration will be applied both during management NCN image customization and node personalization. As a result its name is being changed to `management-{{recipe.version}}` in the default bootprep input file.

Update the SAT documentation to use this new naming convention. For now, we are assuming the Alice recipe version is going to be 23.03. If that changes, we will update it in the docs.

## Issues and Related PRs

* Resolves [CRAYSAT-1610](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1610)

## Testing

No testing was performed for this doc change. It's not really something we can test. It's just changing some examples.

## Risks and Mitigations

This is a pretty low-risk change as it's just changing examples to be more consistent with the CFS configuration naming convention being implemented in Alice.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

