### PR TITLE
CRAYSAT-1648: Document that playbook field supports Jinja2

### DIFF
--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -320,6 +320,7 @@ a Jinja2 template:
 - The following keys of each layer under the `layers` key in a
   configuration:
   - `name`
+  - `playbook`
   - `git.branch`
   - `product.version`
   - `product.branch`


### PR DESCRIPTION
## Summary and Scope

Document that the playbook field in a layer of a CFS configuration in a `sat bootprep` input file now supports rendering as a Jinja2 template.

## Issues and Related PRs

* Resolves [CRAYSAT-1648](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1648)
* Merge with https://github.com/Cray-HPE/sat/pull/88

## Testing

### Tested on:

  * GitHub

### Test description:

Inspected markdown rendering in GitHub.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable