### PR TITLE
CRAYSAT-1662: Document automatic conversion of hyphens to underscores

### DIFF
--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -344,6 +344,18 @@ values can be viewed by running `sat bootprep list-vars`. For more information
 on options that may be used with the `list-vars` subcommand, refer to the man page
 for the `sat bootprep` subcommand.
 
+#### Using Hyphens in HPC CSM Software Recipe Variables
+
+Variable names with hyphens are not allowed in Jinja2 expressions because they
+are parsed as an arithmetic expression instead of a single variable.
+To support product names with hyphens, `sat bootprep` converts
+hyphens to underscores in all top-level keys in the software recipe variables.
+It also converts any variables passed to the command using `--vars` or `--vars-file`.
+When referring to a variable with hyphens in the bootprep input file, keep
+this in mind. For example, to refer to the product version variable for
+`slingshot-host-software` in the bootprep input file, you would write
+`"{{slingshot_host_software.version}}"`.
+
 #### HPC CSM Software Recipe Variable Substitution Example
 
 The following example bootprep input file shows how a COS version can be


### PR DESCRIPTION
This commit adds detail on how hyphens are converted to underscores when reading software recipe variables.

Test Description: Read the document and checked spelling.

Co-authored-by: Jessica Dehn <109693479+jld-dehn-hpe@users.noreply.github.com>
(cherry picked from commit 222c6bde9399fd0b6e1e3ea2cb88df475a226d77)

See #70 

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable