### PR TITLE
STP-3447: Add docs-product-manifest.yaml file to release/2.5

### DIFF
--- a/docs-product-manifest.yaml.in
+++ b/docs-product-manifest.yaml.in
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# A manifest that defines the behavior for unifying docs across all CSM-based
+# products.
+#
+name: sat
+version: '@VERSION@'
+docs_product_manifest_version: ^0.1.0
+ 
+csm-based-install-docs: docs/install.md
+ 
+csm-based-upgrade-docs: docs/upgrade.md

--- a/docs-sat.spec
+++ b/docs-sat.spec
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -40,6 +40,10 @@ in Markdown format starting at /usr/share/doc/sat/README.md.
 %setup -q
 
 %build
+TEMPLATE_FILES=(docs-product-manifest.yaml)
+for f in "${TEMPLATE_FILES[@]}"; do
+    sed -e "s/@VERSION@/%{version}-%{release}/" "${f}.in" > ${f}
+done
 
 %install
 install -m 755 -d %{buildroot}/usr/share/doc/sat/
@@ -50,6 +54,8 @@ cat rpm/README.md > %{buildroot}/usr/share/doc/sat/README.md
 # Add an empty line between the files.
 echo >> %{buildroot}/usr/share/doc/sat/README.md
 cat docs/README.md >> %{buildroot}/usr/share/doc/sat/README.md
+# Add the manifest file for unified docs
+install docs-product-manifest.yaml %{buildroot}/usr/share/doc/sat/
 
 %clean
 


### PR DESCRIPTION
## Summary and Scope

Add a manifest that defines the behavior for unifying docs across all CSM-based products. Add the file `docs-product-manifest.yaml` to the RPM and substitute in the version of the docs-sat RPM into the file. It's not clear what this version is really being used for, but we are adding it here and making sure it matches the version of the docs, which is generated from a tag.

## Issues and Related PRs

* Resolves [STP-3447](https://jira-pro.its.hpecorp.net:8443/browse/STP-3447)

## Testing

Pushed and let Jenkins build RPM. Downloaded RPM, extracted with `rpm2cpio` and `cpio -idvmu`, and then verified inclusion of `docs-product-manifest.yaml` and the correct version substitution.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable