### PR TITLE
STP-3519: Update cne-install reference in release/2.4

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ stream.
   procedures for a newer distribution. The newly installed version will become
   the default.
 
-    In SAT 2.4 and newer, you can instead upgrade the product stream by using the
+    In SAT 2.4, you can instead upgrade the product stream by using the
     Compute Node Environment (CNE) installer. It is recommended that you upgrade
     SAT with the CNE installer because the process is both automated and logged
     to help you save time. For more information, see


### PR DESCRIPTION
## Summary and Scope

In the `release/2.4` branch of the docs, it says "In SAT 2.4 and newer" when referencing `cne-install`. This is no longer true with the new IUF tool for Alice. It should just be "in SAT 2.4" for line 24 of the `install.md` file.

## Issues and Related PRs

* Resolves [STP-3519](https://jira-pro.its.hpecorp.net:8443/browse/STP-3519)

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable