### PR TITLE
STP-3470: Add information about `sat bootprep run` summary output to integration

### DIFF
--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -553,6 +553,43 @@ default bootprep input files described in [Accessing Default Bootprep Input
 Files](#accessing-default-bootprep-input-files). The `sat bootprep
 generate-example` command will be updated in a future release of SAT.
 
+## Summary of SAT Bootprep Results
+
+The `sat bootprep run` command uses information from the bootprep input file to
+create CFS configurations, IMS images, and BOS session templates. For easy
+reference, the command also includes output summarizing the final creation
+results. The following example shows a sample table output.
+
+```screen
+ncn-m001# sat bootprep run
+...
+################################################################################
+CFS configurations
+################################################################################
++------------------+
+| name             |
++------------------+
+| example-config-1 |
+| example-config-2 |
++------------------+
+################################################################################
+IMS images
+################################################################################
++---------------+--------------------------------------+--------------------------------------+----------------+----------------------------+
+| name          | preconfigured_image_id               | final_image_id                       | configuration  | configuration_group_names  |
++---------------+--------------------------------------+--------------------------------------+----------------+----------------------------+
+| example-image | c1bcaf00-109d-470f-b665-e7b37dedb62f | a22fb912-22be-449b-a51b-081af2d7aff6 | example-config | Compute                    |
++---------------+--------------------------------------+--------------------------------------+----------------+----------------------------+
+################################################################################
+BOS session templates
+################################################################################
++------------------+----------------+
+| name             | configuration  |
++------------------+----------------+
+| example-template | example-config |
++------------------+----------------+
+```
+
 ## Editing HPC CSM Software Recipe Defaults
 
 You might need to edit the default bootprep input files delivered by the HPC


### PR DESCRIPTION
## Summary and Scope

Added information about the new summary output for `sat bootprep run`.

## Issues and Related PRs

* Partly resolves [STP-3470](https://jira-pro.its.hpecorp.net:8443/browse/STP-3470)
* Change will also be needed in `release/2.5`

**Note:** My plan is to separate the work required in [STP-3470](https://jira-pro.its.hpecorp.net:8443/browse/STP-3470) into four separate PRs for integration so that the information is easier to review. Once these are approved, I'll cherry pick all changes as one PR to `release/2.5`.

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable