### PR TITLE
STP-3520: Remove active info for `sat showrev` in release/2.5

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@
 ## [SAT Uninstall and Downgrade](uninstall_and_downgrade.md)
 
 - [Uninstall: Remove a Version of SAT](uninstall_and_downgrade.md#uninstall-remove-a-version-of-sat)
-- [Activate: Switch Between SAT Versions](uninstall_and_downgrade.md#activate-switch-between-sat-versions)
+- [Downgrade: Switch Between SAT Versions](uninstall_and_downgrade.md#downgrade-switch-between-sat-versions)
 
 ## [SAT on an External System](external_system.md)
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -151,7 +151,7 @@ to install SAT as a separate product stream. Any version of SAT installed as a s
   stream. Otherwise, there will be no entry for this version of SAT in the output of `sat showrev`.
 
 - The `sat-install-utility` container image is only available with the full SAT product stream. This container image
-  provides uninstall and activate functionality when used with the `prodmgr` command. (In SAT 2.3 and older, SAT was
+  provides uninstall and downgrade functionality when used with the `prodmgr` command. (In SAT 2.3 and older, SAT was
   only available to install as a separate product stream. Because these versions were packaged with
   `sat-install-utility`, it is still possible to uninstall these versions of SAT.)
 
@@ -161,7 +161,7 @@ to install SAT as a separate product stream. Any version of SAT installed as a s
   only available with the full SAT product stream.
 
 If the SAT product stream is not installed, there will be no configuration content for SAT in VCS. Therefore, CFS
-configurations that apply to management NCNs (for example, `management-23.05`) should not include a SAT layer.
+configurations that apply to management NCNs (for example, `management-23.4.0`) should not include a SAT layer.
 
 The SAT configuration layer modifies the permissions of files left over from prior installations of SAT, so that the
 Keycloak username that authenticates to the API gateway cannot be read by users other than `root`. Specifically, it

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -362,17 +362,17 @@ The SAT product uploads additional information to the `cray-product-catalog`
 Kubernetes ConfigMap detailing the components it provides, including container
 (Docker) images, Helm charts, RPMs, and package repositories.
 
-This information is used to support uninstall and activation of SAT product
+This information is used to support uninstall and downgrade of SAT product
 versions moving forward.
 
 ### Support for Uninstall and Activation of SAT Versions
 
 Beginning with the 2.2 release, SAT now provides partial support for the
-uninstall and activation of the SAT product stream.
+uninstall and downgrade of the SAT product stream.
 
 For more information, see [Uninstall: Remove a Version of
-SAT](uninstall_and_downgrade.md#uninstall-remove-a-version-of-sat) and [Activate: Switch
-Between SAT Versions](uninstall_and_downgrade.md#activate-switch-between-sat-versions).
+SAT](uninstall_and_downgrade.md#uninstall-remove-a-version-of-sat) and [Downgrade: Switch
+Between SAT Versions](uninstall_and_downgrade.md#downgrade-switch-between-sat-versions).
 
 ### Improvements to `sat status`
 

--- a/docs/uninstall_and_downgrade.md
+++ b/docs/uninstall_and_downgrade.md
@@ -13,21 +13,17 @@ This procedure can be used to uninstall a version of SAT.
 
 1. Use `sat showrev` to list versions of SAT.
 
-   **Note:** It is not recommended to uninstall a version designated as "active".
-   If the active version is uninstalled, then the activate procedure must be executed
-   on a remaining version.
-
    ```screen
    ncn-m001# sat showrev --products --filter product_name=sat
    ###############################################################################
    Product Revision Information
    ###############################################################################
-   +--------------+-----------------+--------+-------------------+-----------------------+
-   | product_name | product_version | active | images            | image_recipes         |
-   +--------------+-----------------+--------+-------------------+-----------------------+
-   | sat          | 2.3.3           | True   | -                 | -                     |
-   | sat          | 2.2.10          | False  | -                 | -                     |
-   +--------------+-----------------+--------+-------------------+-----------------------+
+   +--------------+-----------------+-------------------+-----------------------+
+   | product_name | product_version | images            | image_recipes         |
+   +--------------+-----------------+-------------------+-----------------------+
+   | sat          | 2.3.3           | -                 | -                     |
+   | sat          | 2.2.10          | -                 | -                     |
+   +--------------+-----------------+-------------------+-----------------------+
    ```
 
 1. Use `prodmgr` to uninstall a version of SAT.
@@ -49,13 +45,13 @@ This procedure can be used to uninstall a version of SAT.
    Deleted sat-2.2.10 from product catalog.
    ```
 
-## Activate: Switch Between SAT Versions
+## Downgrade: Switch Between SAT Versions
 
 This procedure can be used to downgrade the active version of SAT.
 
 ### Prerequisites
 
-- Only versions 2.2 or newer of SAT can be activated. Older versions must be activated manually.
+- Only versions 2.2 or newer of SAT can be switched. Older versions must be switched manually.
 - CSM version 1.2 or newer must be installed, so that the `prodmgr` command is available.
 
 ### Procedure
@@ -67,48 +63,30 @@ This procedure can be used to downgrade the active version of SAT.
    ###############################################################################
    Product Revision Information
    ###############################################################################
-   +--------------+-----------------+--------+--------------------+-----------------------+
-   | product_name | product_version | active | images             | image_recipes         |
-   +--------------+-----------------+--------+--------------------+-----------------------+
-   | sat          | 2.3.3           | True   | -                  | -                     |
-   | sat          | 2.2.10          | False  | -                  | -                     |
-   +--------------+-----------------+--------+--------------------+-----------------------+
+   +--------------+-----------------+--------------------+-----------------------+
+   | product_name | product_version | images             | image_recipes         |
+   +--------------+-----------------+--------------------+-----------------------+
+   | sat          | 2.3.3           | -                  | -                     |
+   | sat          | 2.2.10          | -                  | -                     |
+   +--------------+-----------------+--------------------+-----------------------+
    ```
 
-1. Use `prodmgr` to activate a different version of SAT.
+1. Use `prodmgr` to switch to a different version of SAT.
 
-   This command will do three things:
+   This command will do two things:
 
    - For all hosted-type package repositories associated with this version of SAT, set them as the sole member
-     of their corresponding group-type repository. For example, activating SAT version `2.2.10`
+     of their corresponding group-type repository. For example, switching to SAT version `2.2.10`
      sets the repository `sat-2.2.10-sle-15sp2` as the only member of the `sat-sle-15sp2` group.
-   - Set the version `2.2.10` as active within the product catalog, so that it appears active in the output of
-     `sat showrev`.
    - Ensure that the SAT CFS configuration content exists as a layer in all CFS configurations that are
      associated with NCNs with the role "Management" and subrole "Master" (for example, the CFS configuration
-     `management-23.05`). Specifically, it will ensure that the layer refers to the version of SAT CFS
-     configuration content associated with the version of SAT being activated.
+     `management-23.4.0`). Specifically, it will ensure that the layer refers to the version of SAT CFS
+     configuration content associated with the version of SAT to which you are switching.
 
    ```screen
-   ncn-m001# prodmgr activate sat 2.2.10
-   Repository sat-2.2.10-sle-15sp2 is now the default in sat-sle-15sp2.
-   Set sat-2.2.10 as active in product catalog.
-   Updated CFS configurations: [management-23.05]
-   ```
-
-1. Verify that the chosen version is marked as active.
-
-   ```screen
-   ncn-m001# sat showrev --products --filter product_name=sat
-   ###############################################################################
-   Product Revision Information
-   ###############################################################################
-   +--------------+-----------------+--------+--------------------+-----------------------+
-   | product_name | product_version | active | images             | image_recipes         |
-   +--------------+-----------------+--------+--------------------+-----------------------+
-   | sat          | 2.3.3           | False  | -                  | -                     |
-   | sat          | 2.2.10          | True   | -                  | -                     |
-   +--------------+-----------------+--------+--------------------+-----------------------+
+   ncn-m001# prodmgr activate sat 2.5.15
+   Repository sat-2.5.15-sle-15sp4 is now the default in sat-sle-15sp4.
+   Updated CFS configurations: [management-23.4.0]
    ```
 
 1. Apply the modified CFS configuration to the management NCNs.
@@ -126,7 +104,7 @@ This procedure can be used to downgrade the active version of SAT.
    to be applied to the management NCNs.
 
    ```screen
-   ncn-m001# export CFS_CONFIG_NAME="management-23.05"
+   ncn-m001# export CFS_CONFIG_NAME="management-23.4.0"
    ```
 
    **Note:** Refer to the output from the `prodmgr activate` command to find
@@ -134,7 +112,7 @@ This procedure can be used to downgrade the active version of SAT.
    was modified, use the first one.
 
    ```screen
-   INFO: Successfully saved CFS configuration "management-23.05"
+   INFO: Successfully saved CFS configuration "management-23.4.0"
    ```
 
 1. Obtain the name of the CFS configuration layer for SAT and save it in an

--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -559,7 +559,7 @@ uses the value `management-{{recipe.version}}` as the name of the CFS
 configuration. This value uses a Jinja2 template to include the HPC CSM Software
 Recipe version in the name of the CFS configuration. For example, when `sat
 bootprep` is run against the default bootprep input file in HPC CSM Software
-Recipe version `23.05`, a configuration named `management-23.05` is created.
+Recipe version 23.04, a configuration named `management-23.4.0` is created.
 
 This default management CFS configuration name might be acceptable for your
 system. However, it is possible to use a different name. `sat bootprep` creates
@@ -578,28 +578,28 @@ desired configuration for each of the management nodes.
 
 ```screen
 ncn-m001# sat status --fields xname,role,subrole,desiredconfig --filter role=management
-+----------------+------------+---------+------------------+
-| xname          | Role       | SubRole | Desired Config   |
-+----------------+------------+---------+------------------+
-| x3000c0s1b0n0  | Management | Master  | management-23.05 |
-| x3000c0s3b0n0  | Management | Master  | management-23.05 |
-| x3000c0s5b0n0  | Management | Master  | management-23.05 |
-| x3000c0s7b0n0  | Management | Worker  | management-23.05 |
-| x3000c0s9b0n0  | Management | Worker  | management-23.05 |
-| x3000c0s11b0n0 | Management | Worker  | management-23.05 |
-| x3000c0s13b0n0 | Management | Worker  | management-23.05 |
-| x3000c0s17b0n0 | Management | Storage | management-23.05 |
-| x3000c0s19b0n0 | Management | Storage | management-23.05 |
-| x3000c0s21b0n0 | Management | Storage | management-23.05 |
-| x3000c0s25b0n0 | Management | Worker  | management-23.05 |
-+----------------+------------+---------+------------------+
++----------------+------------+---------+-------------------+
+| xname          | Role       | SubRole | Desired Config    |
++----------------+------------+---------+-------------------+
+| x3000c0s1b0n0  | Management | Master  | management-23.4.0 |
+| x3000c0s3b0n0  | Management | Master  | management-23.4.0 |
+| x3000c0s5b0n0  | Management | Master  | management-23.4.0 |
+| x3000c0s7b0n0  | Management | Worker  | management-23.4.0 |
+| x3000c0s9b0n0  | Management | Worker  | management-23.4.0 |
+| x3000c0s11b0n0 | Management | Worker  | management-23.4.0 |
+| x3000c0s13b0n0 | Management | Worker  | management-23.4.0 |
+| x3000c0s17b0n0 | Management | Storage | management-23.4.0 |
+| x3000c0s19b0n0 | Management | Storage | management-23.4.0 |
+| x3000c0s21b0n0 | Management | Storage | management-23.4.0 |
+| x3000c0s25b0n0 | Management | Worker  | management-23.4.0 |
++----------------+------------+---------+-------------------+
 ```
 
 To overwrite the desired configuration using `sat bootprep`, ensure the bootprep
 input file specifies to create a configuration with the same name
-(`management-23.05` in the example above). To create a different configuration,
+(`management-23.4.0` in the example above). To create a different configuration,
 ensure the bootprep input file specifies to create a configuration with a
-different name than the desired configuration (different than `management-23.05`
+different name than the desired configuration (different than `management-23.4.0`
 in the example above).
 
 ### Upgrading a Single Product and Overriding its Default Version


### PR DESCRIPTION
## Summary and Scope

- Removed the "active" column from `sat showrev` for SAT 2.5. It is still possible to do all the same stuff that "activate" did even with the removal of this column (with the exception of actually updating the value in that column).
- Removed examples and references to the "active" column and "activate" wording throughout.
- Updated Alice recipe number throughout

(cherry picked from commit 5ac3febdebd99185100bbc7099a5c1f5bf4b1b58)

## Issues and Related PRs

* Resolves [STP-3520](https://jira-pro.its.hpecorp.net:8443/browse/STP-3520)

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable