### PR TITLE
CRAYSAT-1700: Change default BOS version used by SAT to v2

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -86,6 +86,8 @@ v1.5.
 v1.3.
 v1.3.2.
 v1.4.1.
+# The spell checker does not allow v2 when referring to BOS v2.
+v2
 # The spell checker allows acronyms, but does not allow pluralized acronyms
 # (e.g. "NCNs").
 APIs

--- a/docs/usage/change_bos_version.md
+++ b/docs/usage/change_bos_version.md
@@ -1,6 +1,6 @@
 # Change the BOS Version
 
-By default, SAT uses Boot Orchestration Service (BOS) version one. You can
+By default, SAT uses Boot Orchestration Service (BOS) version two (v2). You can
 select the BOS version to use for individual commands with the `--bos-version`
 option. For more information on this option, refer to the man page for a specific
 command.
@@ -16,17 +16,17 @@ BOS version desired in the `api_version` setting.
 
    ```screen
    [bos]
-   api_version = "v1"
+   api_version = "v2"
    ```
 
-   In this example, SAT is using BOS version `"v1"`.
+   In this example, SAT is using BOS version `"v2"`.
 
 1. Change the line specifying the `api_version` to the BOS version desired (for
-   example, `"v2"`).
+   example, `"v1"`).
 
    ```screen
    [bos]
-   api_version = "v2"
+   api_version = "v1"
    ```
 
 1. If applicable, uncomment the `api_version` line.


### PR DESCRIPTION


## Summary and Scope

The default BOS version used by `sat` commands is now v2. Update the docs to state this. Update the procedure for changing the version to show examples of changing the BOS version from v2 back to v1.

## Issues and Related PRs

* Resolves [CRAYSAT-1700](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1700)
* The actual default value change is here: https://github.com/Cray-HPE/sat/pull/115

## Testing

N/A

## Risks and Mitigations

Low risk. The admin can always change back.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

