### PR TITLE
CRAYSAT-1705: Update `sat` version in release notes

### DIFF
--- a/docs/release_notes/sat_2.5_release_notes.md
+++ b/docs/release_notes/sat_2.5_release_notes.md
@@ -2,7 +2,7 @@
 
 The 2.5.17 version of the SAT product includes:
 
-- Version 3.21.3 of the `sat` python package and CLI.
+- Version 3.21.4 of the `sat` python package and CLI.
 - Version 2.0.0-1 of the `sat-podman` wrapper script.
 - Version 1.6.0 of the `sat-install-utility` container image.
 - Version 3.3.1 of the `cfs-config-util` container image.


### PR DESCRIPTION
## Summary and Scope

Realized we need to update the `sat` version in our 2.5 release notes because of Ryan's PR for CRAYSAT-1705. I was able to add this as another commit to the integration branch since my PR is still open, but I'm creating a new PR here.

## Issues and Related PRs

Resolves [CRAYSAT-1705](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1705)

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable