### PR TITLE
STP-3578: Italicize guides consistently in release branch

### DIFF
--- a/docs/external_system.md
+++ b/docs/external_system.md
@@ -276,7 +276,7 @@ use externally-accessible API endpoints exposed by CSM.
    Keycloak and must have its *assigned role* set to *admin*. For more
    information on editing *Role Mappings*, see *Create Internal User Accounts
    in the Keycloak Shasta Realm* in the
-   [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+   [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
    For more information on authentication types and authentication credentials,
    see [SAT Command Authentication](introduction.md#sat-command-authentication).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,18 +6,18 @@ The Install and Upgrade Framework (IUF) provides commands which install,
 upgrade, and deploy products on systems managed by CSM. IUF capabilities are
 described in detail in the [IUF
 section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the
-[Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+[*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 The initial install and upgrade workflows described in the
-[HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM
-(S-8052)](https://www.hpe.com/support/ex-S-8052) detail when and how to use
+[*HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM
+(S-8052)*](https://www.hpe.com/support/ex-S-8052) detail when and how to use
 IUF with a new release of SAT or any other HPE Cray EX product.
 
 This document **does not** replicate install, upgrade, or deployment procedures
-detailed in the [Cray System Management
-Documentation](https://cray-hpe.github.io/docs-csm/). This document provides
+detailed in the [*Cray System Management
+Documentation*](https://cray-hpe.github.io/docs-csm/). This document provides
 details regarding software and configuration content specific to SAT which is
-needed when installing, upgrading, or deploying a SAT release. The [Cray
-System Management Documentation](https://cray-hpe.github.io/docs-csm/) will
+needed when installing, upgrading, or deploying a SAT release. The [*Cray
+System Management Documentation*](https://cray-hpe.github.io/docs-csm/) will
 indicate when sections of this document should be referred to for detailed
 information.
 
@@ -39,7 +39,7 @@ IUF will perform the following tasks for a release of SAT.
 
 IUF uses a variety of CSM and SAT tools when performing these tasks. The [IUF
 section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the
-[Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/)
+[*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/)
 describes how to use these tools directly if it is desirable to use them
 instead of IUF.
 
@@ -87,8 +87,8 @@ To run SAT commands on the manager NCNs, you must first set up authentication
 to the API gateway. The admin account used to authenticate with `sat auth`
 must be enabled in Keycloak and must have its *assigned role* set to *admin*.
 For more information on editing *Role Mappings*, see *Create Internal User Accounts
-in the Keycloak Shasta Realm* in the [Cray System Management
-Documentation](https://cray-hpe.github.io/docs-csm/). For more information on
+in the Keycloak Shasta Realm* in the [*Cray System Management
+Documentation*](https://cray-hpe.github.io/docs-csm/). For more information on
 authentication types and authentication credentials, see [SAT Command
 Authentication](introduction.md#sat-command-authentication).
 
@@ -96,7 +96,7 @@ Authentication](introduction.md#sat-command-authentication).
 
 - The `sat` CLI has been installed following the [IUF
   section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the
-  [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+  [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 
 #### Procedure
 
@@ -154,7 +154,7 @@ Information](#set-system-revision-information)).
 
 - The SAT CLI has been installed following the [IUF
   section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the
-  [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+  [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 - The SAT configuration file has been created (See [Authenticate SAT
   Commands](#authenticate-sat-commands)).
 - CSM has been installed and verified.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -123,8 +123,8 @@ generate the S3 access key and secret keys and write them to a local file. This
 must be done on every Kubernetes manager node where SAT commands are run.
 
 For more information on authentication requests, see *System Security and
-Authentication* in the [Cray System Management
-Documentation](https://cray-hpe.github.io/docs-csm/). The following is a table
+Authentication* in the [*Cray System Management
+Documentation*](https://cray-hpe.github.io/docs-csm/). The following is a table
 describing SAT commands and the types of authentication they require.
 
 |SAT Subcommand|Authentication/Credentials Required|Man Page|Description|

--- a/docs/release_notes/sat_2.5_release_notes.md
+++ b/docs/release_notes/sat_2.5_release_notes.md
@@ -60,7 +60,7 @@ line. It provides a table summarizing information for all jobs on the system.
   nodes in the `bos-operations` stage.
 - The `--staged-session` option was added to `sat bootsys`. It can be used to
   create staged BOS sessions. For more information, refer to **Staging Changes
-  with BOS** in the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+  with BOS** in the [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 
 ## Changes to Other `sat` Commands
 
@@ -76,10 +76,10 @@ The new Install and Upgrade Framework (IUF) provides commands which install,
 upgrade, and deploy products with the help of `sat bootprep` on HPE Cray EX
 systems managed by Cray System Management (CSM). IUF capabilities are described
 in detail in the [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/)
-of the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+of the [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 The initial install and upgrade workflows described in the
-[HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM
-(S-8052)](https://www.hpe.com/support/ex-S-8052) detail when and how to use
+[*HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM
+(S-8052)*](https://www.hpe.com/support/ex-S-8052) detail when and how to use
 IUF with a new release of SAT or any other HPE Cray EX product.
 
 Because IUF now handles NCN personalization, information about this process was
@@ -87,7 +87,7 @@ removed from the SAT documentation. Other sections in the documentation were
 also revised to support the new Install and Upgrade Framework. For example, the
 [SAT Installation](../install.md) and [SAT Upgrade](../upgrade.md) sections of this
 guide now provide details on software and configuration content specific to SAT.
-The [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/)
+The [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/)
 will indicate when these sections should be referred to for detailed information.
 
 For more information on the relationship between `sat bootprep` and IUF, see

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -6,18 +6,18 @@ The Install and Upgrade Framework (IUF) provides commands which install,
 upgrade, and deploy products on systems managed by CSM. IUF capabilities are
 described in detail in the [IUF
 section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the
-[Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+[*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 The initial install and upgrade workflows described in the
-[HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM
-(S-8052)](https://www.hpe.com/support/ex-S-8052) detail when and how to use
+[*HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM
+(S-8052)*](https://www.hpe.com/support/ex-S-8052) detail when and how to use
 IUF with a new release of SAT or any other HPE Cray EX product.
 
 This document **does not** replicate install, upgrade, or deployment procedures
-detailed in the [Cray System Management
-Documentation](https://cray-hpe.github.io/docs-csm/). This document provides
+detailed in the [*Cray System Management
+Documentation*](https://cray-hpe.github.io/docs-csm/). This document provides
 details regarding software and configuration content specific to SAT which is
-needed when installing, upgrading, or deploying a SAT release. The [Cray
-System Management Documentation](https://cray-hpe.github.io/docs-csm/) will
+needed when installing, upgrading, or deploying a SAT release. The [*Cray
+System Management Documentation*](https://cray-hpe.github.io/docs-csm/) will
 indicate when sections of this document should be referred to for detailed
 information.
 
@@ -39,7 +39,7 @@ IUF will perform the following tasks for a release of SAT.
 
 IUF uses a variety of CSM and SAT tools when performing these tasks. The [IUF
 section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the
-[Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/)
+[*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/)
 describes how to use these tools directly if it is desirable to use them
 instead of IUF.
 

--- a/docs/usage/sat_and_iuf.md
+++ b/docs/usage/sat_and_iuf.md
@@ -5,7 +5,7 @@ upgrade, and deploy products on systems managed by CSM with the help of
 `sat bootprep`. Outside of IUF, it is uncommon to use `sat bootprep`.
 For more information on IUF, see the
 [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of
-the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+the [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 For more information on `sat bootprep`, see [SAT Bootprep](sat_bootprep.md).
 
 ## Variable Substitutions
@@ -25,7 +25,7 @@ version combinations being installed by the current IUF activity, and they are
 found inside IUF's internal `session_vars.yaml` file. For more information on
 IUF and variable substitutions, see the
 [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of
-the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+the [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 
 ### SAT Variable Limitations
 

--- a/docs/usage/sat_bootprep.md
+++ b/docs/usage/sat_bootprep.md
@@ -16,7 +16,7 @@ install, upgrade, and deploy products on systems managed by CSM. Outside of IUF,
 it is uncommon to use `sat bootprep`. For more information on this relationship,
 see [SAT and IUF](sat_and_iuf.md). For more information on IUF, see the
 [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of
-the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+the [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 
 ## SAT Bootprep vs SAT Bootsys
 
@@ -84,7 +84,7 @@ method is used, the layer is created in CFS by looking up relevant configuration
 information (including the configuration repository and commit information) from
 the cray-product-catalog Kubernetes ConfigMap as necessary. A version may be
 supplied. However, if it is absent, the version is assumed to be the latest
-version found in the cray-product-catalog.
+version found in the `cray-product-catalog`.
 
 Alternatively, a configuration layer can be defined by explicitly referencing
 the desired configuration repository. You must then specify the intended version
@@ -362,7 +362,7 @@ directly with `sat bootprep`, you might encounter some limitations. For more
 information on SAT variable limitations, see [SAT and IUF](sat_and_iuf.md).
 For more information on IUF and variable substitutions, see the
 [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of
-the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/).
+the [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 
 #### Select an HPC CSM Software Recipe Version
 


### PR DESCRIPTION
## Summary and Scope

- Consistently italicize guide titles
- Other minor clean-up work to finalize 23.04 content
  (cherry picked from commit 7c35f841090f2eaab7e058dbab7ee23774bdd647)

## Issues and Related PRs

* Resolves [STP-3578](https://jira-pro.its.hpecorp.net:8443/browse/STP-3578)
* Change will also be needed in `release/2.5`

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable