### PR TITLE
Update Alice release number to 23.05 in release branch

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -215,7 +215,7 @@ to install SAT as a separate product stream. Any version of SAT installed as a s
   only available with the full SAT product stream.
 
 If the SAT product stream is not installed, there will be no configuration content for SAT in VCS. Therefore, CFS
-configurations that apply to management NCNs (for example, `management-23.4.0`) should not include a SAT layer.
+configurations that apply to management NCNs (for example, `management-23.5.0`) should not include a SAT layer.
 
 The SAT configuration layer modifies the permissions of files left over from prior installations of SAT, so that the
 Keycloak username that authenticates to the API gateway cannot be read by users other than `root`. Specifically, it

--- a/docs/uninstall_and_downgrade.md
+++ b/docs/uninstall_and_downgrade.md
@@ -80,13 +80,13 @@ This procedure can be used to downgrade the active version of SAT.
      sets the repository `sat-2.2.10-sle-15sp2` as the only member of the `sat-sle-15sp2` group.
    - Ensure that the SAT CFS configuration content exists as a layer in all CFS configurations that are
      associated with NCNs with the role "Management" and subrole "Master" (for example, the CFS configuration
-     `management-23.4.0`). Specifically, it will ensure that the layer refers to the version of SAT CFS
+     `management-23.5.0`). Specifically, it will ensure that the layer refers to the version of SAT CFS
      configuration content associated with the version of SAT to which you are switching.
 
    ```screen
    ncn-m001# prodmgr activate sat 2.5.15
    Repository sat-2.5.15-sle-15sp4 is now the default in sat-sle-15sp4.
-   Updated CFS configurations: [management-23.4.0]
+   Updated CFS configurations: [management-23.5.0]
    ```
 
 1. Apply the modified CFS configuration to the management NCNs.
@@ -104,7 +104,7 @@ This procedure can be used to downgrade the active version of SAT.
    to be applied to the management NCNs.
 
    ```screen
-   ncn-m001# export CFS_CONFIG_NAME="management-23.4.0"
+   ncn-m001# export CFS_CONFIG_NAME="management-23.5.0"
    ```
 
    **Note:** Refer to the output from the `prodmgr activate` command to find
@@ -112,7 +112,7 @@ This procedure can be used to downgrade the active version of SAT.
    was modified, use the first one.
 
    ```screen
-   INFO: Successfully saved CFS configuration "management-23.4.0"
+   INFO: Successfully saved CFS configuration "management-23.5.0"
    ```
 
 1. Obtain the name of the CFS configuration layer for SAT and save it in an


### PR DESCRIPTION
## Summary and Scope

Alice is officially releasing this week as recipe 23.05. Updating a few minor places in our documentation that reference the recipe as 23.04.
(cherry picked from commit c7b59b9bd663f69933131197e3e9b73331a35bce)

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable