### PR TITLE
CRAYSAT-1670: Remove references to CRUS

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -266,7 +266,6 @@ for each subcommand. Each service or component is listed under the product it be
 - Boot Orchestration Service (BOS)
 - Cray Advanced Platform Monitoring and Control (CAPMC)
 - Ceph
-- Compute Rolling Upgrade Service (CRUS)
 - Etcd
 - Firmware Action Service (FAS)
 - Hardware State Manager (HSM)


### PR DESCRIPTION
## Summary and Scope

This change removes references to CRUS from the SAT documentation since CRUS is being removed from CSM.

## Issues and Related PRs

* Resolves [CRAYSAT-1670](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1670)

## Testing

### Tested on:

  * Local development environment

### Test description:

Build docs.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

