### PR TITLE
STP-3551: Note deprecation of `prodmgr activate` in release

### DIFF
--- a/docs/uninstall_and_downgrade.md
+++ b/docs/uninstall_and_downgrade.md
@@ -49,10 +49,15 @@ This procedure can be used to uninstall a version of SAT.
 
 This procedure can be used to downgrade the active version of SAT.
 
+**Note:** The `prodmgr activate` command is deprecated in SAT 2.6, and the
+ability to switch between SAT versions will be removed in a future release.
+
 ### Prerequisites
 
-- Only versions 2.2 or newer of SAT can be switched. Older versions must be switched manually.
-- CSM version 1.2 or newer must be installed, so that the `prodmgr` command is available.
+- Only versions 2.2 or newer of SAT can be switched. Older versions must be
+  switched manually.
+- CSM version 1.2 or newer must be installed, so that the `prodmgr` command is
+  available.
 
 ### Procedure
 


### PR DESCRIPTION
## Summary and Scope

The functionality for `prodmgr activate` (switching between SAT versions) is being deprecated. I added a note with this information to the relevant section for SAT 2.6. I also did a search throughout the rest of the guide, and I don't think anything else needs to be changed until the functionality of this command is completely removed in a future release.
(cherry picked from commit eec43aa0da0ef451b5e39eb667395c46c0337bd7)

## Issues and Related PRs

* Resolves [STP-3551](https://jira-pro.it.hpe.com:8443/browse/STP-3551)
* Change will also be needed in `release/2.6`

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable