### PR TITLE
CRAYSAT-1726: Add information about multitenancy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@
 - [SAT Bootprep](usage/sat_bootprep.md)
 - [SAT and IUF](usage/sat_and_iuf.md)
 - [Change the BOS Version](usage/change_bos_version.md)
+- [Configure Multi-tenancy](usage/multi-tenancy.md)
 
 ## [SAT Release Notes](release_notes/README.md)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -72,6 +72,7 @@ procedures before using SAT:
 
 - [Authenticate SAT Commands](#authenticate-sat-commands)
 - [Generate SAT S3 Credentials](#generate-sat-s3-credentials)
+- [(Optional) Configure Multi-tenancy](#optional-configure-multi-tenancy)
 - [Set System Revision Information](#set-system-revision-information)
 
 ### Notes on the Procedures
@@ -224,6 +225,12 @@ Information](#set-system-revision-information)).
    manager nodes may be different. This example assumes three manager nodes, where
    the configuration files must be copied from `ncn-m001` to `ncn-m002` and
    `ncn-m003`. Therefore, the list of hosts above is `ncn-m002` and `ncn-m003`.
+
+### (Optional) Configure Multi-tenancy
+
+If SAT is being installed on a multi-tenant system, you can configure the tenant
+name at this point. For more information, see [Configure
+multi-tenancy](usage/multi-tenancy.md).
 
 ### Set System Revision Information
 

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -3,3 +3,4 @@
 - [SAT Bootprep](sat_bootprep.md)
 - [SAT and IUF](sat_and_iuf.md)
 - [Change the BOS Version](change_bos_version.md)
+- [Configure Multi-tenancy](multi-tenancy.md)

--- a/docs/usage/multi-tenancy.md
+++ b/docs/usage/multi-tenancy.md
@@ -1,0 +1,27 @@
+# Configure Multi-tenancy
+
+SAT supports supplying tenant information to CSM services in order to allow
+tenant admins to use SAT within their tenant. By default, the tenant name is
+not set, and SAT will not send any tenant information with its requests to
+CSM services. You can configure the tenant name either in the SAT configuration
+file or on the command line.
+
+## Configure the Tenant Name in the SAT Configuration File
+
+You can set the tenant name in the SAT configuration file using the
+`api_gateway.tenant_name` option. For example:
+
+```toml
+[api_gateway]
+tenant_name = "my_tenant"
+```
+
+## Configure the Tenant Name on the Command Line
+
+You can set the tenant name for each `sat` invocation using the `--tenant-name`
+option. The `--tenant-name` option must be specified before the subcommand
+name. For example:
+
+```screen
+ncn-m001# sat --tenant-name=my_tenant status
+```


### PR DESCRIPTION

## Summary and Scope
This change adds information on how the tenant name can be configured and links it from the installation instructions.

## Issues and Related PRs

* Resolves [CRAYSAT-1726](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1726)

## Testing

### Tested on:

  * Local development environment

### Test description:
Build docs and check for correctness.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

