### PR TITLE
STP-3105: Add reference to Keycloak account info (2.6)

### DIFF
--- a/docs/external_system.md
+++ b/docs/external_system.md
@@ -270,21 +270,23 @@ use externally-accessible API endpoints exposed by CSM.
    username = "user"
    ```
 
-1. Run `sat auth`. Enter your password when prompted.
+1. Run `sat auth`, and enter your password when prompted.
 
    The admin account used to authenticate with `sat auth` must be enabled in
-   Keycloak and must have its *assigned role* set to *admin*. For more
-   information on editing *Role Mappings*, see *Create Internal User Accounts
-   in the Keycloak Shasta Realm* in the
-   [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
-   For more information on authentication types and authentication credentials,
-   see [SAT Command Authentication](introduction.md#sat-command-authentication).
+   Keycloak and must have its *assigned role* set to *admin*.
 
    ```screen
    $ sat auth
    Password for user:
    Succeeded!
    ```
+
+   For more information on authentication types and authentication credentials,
+   see [SAT Command Authentication](introduction.md#sat-command-authentication).
+   For more information on Keycloak accounts and changing *Role Mappings*,
+   refer to both *Configure Keycloak Account* and *Create Internal User
+   Accounts in the Keycloak Shasta Realm* in the [*Cray System Management
+   Documentation*](https://cray-hpe.github.io/docs-csm/).
 
 1. Ensure the files are readable only by the current user.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -85,13 +85,15 @@ procedures before using SAT:
 ### Authenticate SAT Commands
 
 To run SAT commands on the manager NCNs, you must first set up authentication
-to the API gateway. The admin account used to authenticate with `sat auth`
-must be enabled in Keycloak and must have its *assigned role* set to *admin*.
-For more information on editing *Role Mappings*, see *Create Internal User Accounts
-in the Keycloak Shasta Realm* in the [*Cray System Management
-Documentation*](https://cray-hpe.github.io/docs-csm/). For more information on
-authentication types and authentication credentials, see [SAT Command
+to the API gateway. For more information on authentication types and
+authentication credentials, see [SAT Command
 Authentication](introduction.md#sat-command-authentication).
+
+The admin account used to authenticate with `sat auth` must be enabled in
+Keycloak and must have its *assigned role* set to *admin*. For more information
+on Keycloak accounts and changing *Role Mappings*, refer to both *Configure Keycloak
+Account* and *Create Internal User Accounts in the Keycloak Shasta Realm* in
+the [*Cray System Management Documentation*](https://cray-hpe.github.io/docs-csm/).
 
 #### Prerequisites
 


### PR DESCRIPTION
## Summary and Scope

In our instructions for `sat auth`, we need to add a link to better information in `docs-csm` about Keycloak and admin roles.
(cherry picked from commit 98c59a82cf367685a6c820f01f4573d5ccfa3255)

## Issues and Related PRs

Resolves [STP-3105](https://jira-pro.it.hpe.com:8443/browse/STP-3105)

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable