### PR TITLE
CRAYSAT-1790: Add missing services to SAT Dependencies

### DIFF
--- a/docs/about_sat/dependencies.md
+++ b/docs/about_sat/dependencies.md
@@ -130,14 +130,17 @@ None
 ### CSM
 
 - Hardware State Manager (HSM)
-- Kubernetes
-- S3
+- System Layout Service (SLS)
 
 ## `sat status`
 
 ### CSM
 
+- Boot Orchestration Service (BOS)
+- Configuration Framework Service (CFS)
 - Hardware State Manager (HSM)
+- Image Management Service (IMS)
+- System Layout Service (SLS)
 
 ## `sat swap`
 


### PR DESCRIPTION
## Summary and Scope

Add several missing services to `sat status` section of "SAT Dependencies" topic, and fix the incorrect service dependencies under the `sat slscheck` command.

## Issues and Related PRs

* Resolves [CRAYSAT-1790](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1790)
* The same change is being made in docs-csm here: https://github.com/Cray-HPE/docs-csm/pull/4542

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
