### PR TITLE
STP-3754: Update component versioning

### DIFF
--- a/docs/release_notes/sat_2.5_release_notes.md
+++ b/docs/release_notes/sat_2.5_release_notes.md
@@ -1,10 +1,10 @@
 # Changes in SAT 2.5
 
-The 2.5.17 version of the SAT product includes:
+The 2.5.22 version of the SAT product includes:
 
-- Version 3.21.4 of the `sat` python package and CLI.
+- Version 3.21.9 of the `sat` python package and CLI.
 - Version 2.0.0-1 of the `sat-podman` wrapper script.
-- Version 1.6.0 of the `sat-install-utility` container image.
+- Version 1.6.2 of the `sat-install-utility` container image.
 - Version 3.3.1 of the `cfs-config-util` container image.
 
 ## New `sat` Commands


### PR DESCRIPTION
## Summary and Scope

SAT 2.5 will be available as part of a continuous release so that it can be used with the CSM 1.4.4 patch. The component versions in the 2.5 release notes need to be updated to reflect what is current before release.

## Issues and Related PRs

Resolves [STP-3754](https://jira-pro.it.hpe.com:8443/browse/STP-3754)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable