### PR TITLE
STP-3758: Update 2.6 component versions for release

### DIFF
--- a/docs/release_notes/sat_2.6_release_notes.md
+++ b/docs/release_notes/sat_2.6_release_notes.md
@@ -1,8 +1,8 @@
 # Changes in SAT 2.6
 
-The 2.6.11 version of the SAT product includes:
+The 2.6.14 version of the SAT product includes:
 
-- Version 3.25.7 of the `sat` python package and CLI.
+- Version 3.25.10 of the `sat` python package and CLI.
 - Version 2.0.0-1 of the `sat-podman` wrapper script.
 - Version 1.6.2 of the `sat-install-utility` container image.
 


### PR DESCRIPTION
## Summary and Scope

SAT 2.6 will be releasing soon, and we need to update the component versions listed in the release notes to reflect the latest build.

## Issues and Related PRs

* Resolves [STP-3758](https://jira-pro.it.hpe.com:8443/browse/STP-3758)

## Testing

Lint and spell check

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable