### PR TITLE
STP-3724: Add info about SAT transition into CSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # System Admin Toolkit Documentation
 
+**IMPORTANT:** Starting in CSM 1.6.0, SAT is fully included in CSM. There is no longer a separate SAT
+product stream to install. SAT 2.6 releases, which accompanied CSM 1.5, are the last releases of
+SAT as a separate product.
+
+Similarly, the SAT documentation moved to be fully included within the CSM documentation. Starting in
+CSM 1.6.0, find information on SAT in the
+[System Admin Toolkit (SAT) section](https://cray-hpe.github.io/docs-csm/en-16/operations/system_admin_toolkit/)
+of the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/en-16/).
+
 ## Viewing the documentation
 
 The documentation can be viewed in GitHub by navigating to the `docs/`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,14 @@
 # HPE Cray EX System Admin Toolkit (SAT) Guide
 
+**IMPORTANT:** Starting in CSM 1.6.0, SAT is fully included in CSM. There is no longer a separate SAT
+product stream to install. SAT 2.6 releases, which accompanied CSM 1.5, are the last releases of
+SAT as a separate product.
+
+Similarly, the SAT documentation moved to be fully included within the CSM documentation. Starting in
+CSM 1.6.0, find information on SAT in the
+[System Admin Toolkit (SAT) section](https://cray-hpe.github.io/docs-csm/en-16/operations/system_admin_toolkit/)
+of the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/en-16/).
+
 ## [About SAT](about_sat/README.md)
 
 - [View SAT Documentation](about_sat/view_sat_docs.md)


### PR DESCRIPTION
## Summary and Scope

Add information about SAT transitioning into CSM 1.6. This information is specifically for users who might not be aware of the change and come to `docs-sat` for information about "SAT 2.7." We want the information to be clearly visible but not have it obstruct users who need to use documentation for SAT 2.6 or earlier. The info should:

- Describe the SAT product/documentation changes and timing
- Provide links to new SAT info in CSM docs

## Issues and Related PRs

Resolves [STP-3724](https://jira-pro.it.hpe.com:8443/browse/STP-3724)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable